### PR TITLE
fix: Dependabotの設定を修正（enable-beta-ecosystemsをトップレベルに移動）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    enable-beta-ecosystems: true


### PR DESCRIPTION
エラー 'contains additional properties ["enable-beta-ecosystems"] outside of the schema' の対応。
仕様上トップレベルでないと認識されないため。

参考：https://zenn.dev/awonosuke/articles/8ed7f0fe5688b3