### PR TITLE
OAuth2.0のコールバック用関数を用意する

### DIFF
--- a/__tests__/mocks/mock-google-auth.ts
+++ b/__tests__/mocks/mock-google-auth.ts
@@ -23,4 +23,11 @@ export class MockGoogleAuth implements Schema$GoogleAuth {
   setTokens(_token: Schema$GoogleAuthToken): void {
     // モックなので何もしない
   }
+
+  async getTokensFromCode(_code: string): Promise<Schema$GoogleAuthToken> {
+    return {
+      accessToken: "mock-access-token",
+      refreshToken: "mock-refresh-token",
+    };
+  }
 }

--- a/src/handlers/oauth-callback-handler.ts
+++ b/src/handlers/oauth-callback-handler.ts
@@ -1,0 +1,45 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
+import { Config } from "../lib/config";
+import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
+
+export const oauthCallbackHandler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    console.info("Start OAuth callback handler");
+
+    // クエリパラメータから認可コードを取得
+    const code = event.queryStringParameters?.code;
+    if (!code) {
+      throw new Error("Authorization code is missing");
+    }
+
+    // 設定の初期化
+    const config = Config.getInstance();
+    const parameterFetcher = new AwsParameterFetcher();
+    await config.init(parameterFetcher);
+
+    // Google認証の処理
+    const auth = new GoogleAuthAdapter();
+    const tokens = await auth.getTokensFromCode(code);
+
+    // トークンの保存処理をここに実装
+    // TODO: トークンを安全な場所（例：AWS Systems Manager Parameter Store）に保存
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: "認証が完了しました。このウィンドウを閉じてください。",
+      }),
+    };
+  } catch (error) {
+    console.error("Error in OAuth callback handler:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: "認証処理中にエラーが発生しました。",
+      }),
+    };
+  }
+};

--- a/src/lib/google-auth-adapter.ts
+++ b/src/lib/google-auth-adapter.ts
@@ -60,4 +60,20 @@ export class GoogleAuthAdapter implements Schema$GoogleAuth {
       refresh_token: token.refreshToken,
     });
   }
+
+  /**
+   * 認可コードからアクセストークンとリフレッシュトークンを取得する
+   * @param code 認可コード
+   * @returns アクセストークンとリフレッシュトークン
+   */
+  async getTokensFromCode(code: string): Promise<Schema$GoogleAuthToken> {
+    const { tokens } = await this.oauth2Client.getToken(code);
+    if (!tokens.access_token || !tokens.refresh_token) {
+      throw new Error("Failed to get tokens from authorization code");
+    }
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+    };
+  }
 }

--- a/src/types/google-auth.d.ts
+++ b/src/types/google-auth.d.ts
@@ -21,6 +21,13 @@ export type Schema$GoogleAuth = {
    * @param token アクセストークンとリフレッシュトークン
    */
   setTokens(token: Schema$GoogleAuthToken): void;
+
+  /**
+   * 認可コードからアクセストークンとリフレッシュトークンを取得する
+   * @param code 認可コード
+   * @returns アクセストークンとリフレッシュトークン
+   */
+  getTokensFromCode(code: string): Promise<Schema$GoogleAuthToken>;
 };
 
 export type Schema$GoogleAuthToken = {

--- a/template.yaml
+++ b/template.yaml
@@ -108,6 +108,52 @@ Resources:
         Banner:
           # モジュールの解決エラーを解決するために、esbuildのバナーにNode.jsのrequireを追加する
           - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+  OAuthCallbackFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Google OAuth2.0のコールバックを処理するLambda関数
+      Runtime: nodejs22.x
+      Handler: oauth-callback-handler.oauthCallbackHandler
+      Architectures:
+        - x86_64
+      Events:
+        OAuthCallback:
+          Type: Api
+          Properties:
+            Path: /oauth/callback
+            Method: get
+      LoggingConfig:
+        ApplicationLogLevel: DEBUG
+      Layers:
+        # AWS Systems Managerのパラメータストアから設定値を取得するためのLambda Layer
+        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        # AWS Systems Managerのパラメータストアから設定値を取得するためのポリシー
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - "kms:Decrypt"
+                - "ssm:GetParameter"
+              Resource:
+                [
+                  Fn::Sub: "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/da90619d-ebf1-43ae-903d-5035b8ff19e4",
+                  Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/schedule-line-reminder/*",
+                ]
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Format: esm
+        Minify: false
+        OutExtension:
+          - .js=.mjs
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - src/handlers/oauth-callback-handler.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group
     Properties:
@@ -128,6 +174,9 @@ Outputs:
   WebhookApi:
     Description: API Gateway endpoint URL for Prod stage for Webhook function
     Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/webhook/"
+  OAuthCallbackApi:
+    Description: API Gateway endpoint URL for Prod stage for OAuth callback function
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/oauth/callback/"
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:


### PR DESCRIPTION
resolve #28 

OAuth2.0での認可が降りたときに呼び出されるコールバック関数とそのエンドポイントを用意しました。

- API GatewayとLambdaの設定を`template.yml`に追加
  - パス：`/oauth/callback`
- 認可コードからアクセストークンやリフレッシュトークンを取得するhandlerを実装
  - 取得したトークンを保存する処理は別で実装予定。