### PR TITLE
APIGatewayからのレスポンスの共通化＆UTF-8を指定

### DIFF
--- a/__tests__/lib/api-response-builder.test.ts
+++ b/__tests__/lib/api-response-builder.test.ts
@@ -1,0 +1,112 @@
+import { ApiResponseBuilder } from "../../src/lib/api-response-builder";
+
+describe("ApiResponseBuilder", () => {
+  let builder: ApiResponseBuilder;
+
+  beforeEach(() => {
+    builder = new ApiResponseBuilder();
+  });
+
+  describe("success", () => {
+    it("デフォルトのステータスコード200でレスポンスを生成する", () => {
+      const response = builder.success("テストメッセージ");
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers).toEqual({
+        "Content-Type": "application/json; charset=utf-8",
+      });
+      expect(JSON.parse(response.body)).toEqual({
+        message: "テストメッセージ",
+      });
+    });
+
+    it("カスタムステータスコードでレスポンスを生成する", () => {
+      const response = builder.success("テストメッセージ", {
+        statusCode: 201,
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(JSON.parse(response.body)).toEqual({
+        message: "テストメッセージ",
+      });
+    });
+
+    it("データを含むレスポンスを生成する", () => {
+      const testData = { id: 1, name: "テスト" };
+      const response = builder.success("テストメッセージ", {
+        data: testData,
+      });
+
+      expect(JSON.parse(response.body)).toEqual({
+        message: "テストメッセージ",
+        data: testData,
+      });
+    });
+
+    it("カスタムヘッダーを含むレスポンスを生成する", () => {
+      const response = builder.success("テストメッセージ", {
+        headers: {
+          "X-Custom-Header": "custom-value",
+        },
+      });
+
+      expect(response.headers).toEqual({
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Custom-Header": "custom-value",
+      });
+    });
+  });
+
+  describe("error", () => {
+    it("デフォルトのステータスコード500でレスポンスを生成する", () => {
+      const response = builder.error("エラーメッセージ");
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers).toEqual({
+        "Content-Type": "application/json; charset=utf-8",
+      });
+      expect(JSON.parse(response.body)).toEqual({
+        message: "エラーメッセージ",
+      });
+    });
+
+    it("カスタムステータスコードでレスポンスを生成する", () => {
+      const response = builder.error("エラーメッセージ", {
+        statusCode: 400,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body)).toEqual({
+        message: "エラーメッセージ",
+      });
+    });
+
+    it("データを含むエラーレスポンスを生成する", () => {
+      const errorData = {
+        code: "VALIDATION_ERROR",
+        details: "詳細なエラー情報",
+      };
+      const response = builder.error("エラーメッセージ", {
+        data: errorData,
+      });
+
+      expect(JSON.parse(response.body)).toEqual({
+        message: "エラーメッセージ",
+        data: errorData,
+      });
+    });
+
+    it("カスタムヘッダーを含むエラーレスポンスを生成する", () => {
+      const response = builder.error("エラーメッセージ", {
+        headers: {
+          "X-Error-Code": "E001",
+        },
+      });
+
+      expect(response.headers).toEqual({
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Error-Code": "E001",
+      });
+    });
+  });
+});

--- a/__tests__/lib/api-response-builder.test.ts
+++ b/__tests__/lib/api-response-builder.test.ts
@@ -57,27 +57,27 @@ describe("ApiResponseBuilder", () => {
     });
   });
 
-  describe("error", () => {
-    it("デフォルトのステータスコード500でレスポンスを生成する", () => {
-      const response = builder.error("エラーメッセージ");
+  describe("clientError", () => {
+    it("デフォルトのステータスコード400でレスポンスを生成する", () => {
+      const response = builder.clientError("クライアントエラー");
 
-      expect(response.statusCode).toBe(500);
+      expect(response.statusCode).toBe(400);
       expect(response.headers).toEqual({
         "Content-Type": "application/json; charset=utf-8",
       });
       expect(JSON.parse(response.body)).toEqual({
-        message: "エラーメッセージ",
+        message: "クライアントエラー",
       });
     });
 
     it("カスタムステータスコードでレスポンスを生成する", () => {
-      const response = builder.error("エラーメッセージ", {
-        statusCode: 400,
+      const response = builder.clientError("クライアントエラー", {
+        statusCode: 404,
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(404);
       expect(JSON.parse(response.body)).toEqual({
-        message: "エラーメッセージ",
+        message: "クライアントエラー",
       });
     });
 
@@ -86,18 +86,18 @@ describe("ApiResponseBuilder", () => {
         code: "VALIDATION_ERROR",
         details: "詳細なエラー情報",
       };
-      const response = builder.error("エラーメッセージ", {
+      const response = builder.clientError("クライアントエラー", {
         data: errorData,
       });
 
       expect(JSON.parse(response.body)).toEqual({
-        message: "エラーメッセージ",
+        message: "クライアントエラー",
         data: errorData,
       });
     });
 
     it("カスタムヘッダーを含むエラーレスポンスを生成する", () => {
-      const response = builder.error("エラーメッセージ", {
+      const response = builder.clientError("クライアントエラー", {
         headers: {
           "X-Error-Code": "E001",
         },
@@ -106,6 +106,59 @@ describe("ApiResponseBuilder", () => {
       expect(response.headers).toEqual({
         "Content-Type": "application/json; charset=utf-8",
         "X-Error-Code": "E001",
+      });
+    });
+  });
+
+  describe("serverError", () => {
+    it("デフォルトのステータスコード500でレスポンスを生成する", () => {
+      const response = builder.serverError("サーバーエラー");
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers).toEqual({
+        "Content-Type": "application/json; charset=utf-8",
+      });
+      expect(JSON.parse(response.body)).toEqual({
+        message: "サーバーエラー",
+      });
+    });
+
+    it("カスタムステータスコードでレスポンスを生成する", () => {
+      const response = builder.serverError("サーバーエラー", {
+        statusCode: 503,
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(JSON.parse(response.body)).toEqual({
+        message: "サーバーエラー",
+      });
+    });
+
+    it("データを含むエラーレスポンスを生成する", () => {
+      const errorData = {
+        code: "INTERNAL_ERROR",
+        details: "詳細なエラー情報",
+      };
+      const response = builder.serverError("サーバーエラー", {
+        data: errorData,
+      });
+
+      expect(JSON.parse(response.body)).toEqual({
+        message: "サーバーエラー",
+        data: errorData,
+      });
+    });
+
+    it("カスタムヘッダーを含むエラーレスポンスを生成する", () => {
+      const response = builder.serverError("サーバーエラー", {
+        headers: {
+          "X-Error-Code": "E002",
+        },
+      });
+
+      expect(response.headers).toEqual({
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Error-Code": "E002",
       });
     });
   });

--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -36,7 +36,7 @@ export const calendarEventsHandler =
       );
     } catch (error) {
       console.error("Error in calendar events handler:", error);
-      return responseBuilder.error(
+      return responseBuilder.serverError(
         "カレンダーイベントの通知処理中にエラーが発生しました"
       );
     }

--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -4,25 +4,40 @@ import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
 import { Config } from "../lib/config";
 import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { LineMessagingApiClient } from "../line-messaging-api-client";
+import { ApiResponseBuilder } from "../lib/api-response-builder";
+import type { APIGatewayProxyResult } from "aws-lambda";
 
-export const calendarEventsHandler = async () => {
-  console.info("Start calendar events handler");
-  const config = Config.getInstance();
-  const parameterFetcher = new AwsParameterFetcher();
-  await config.init(parameterFetcher);
+export const calendarEventsHandler =
+  async (): Promise<APIGatewayProxyResult> => {
+    const responseBuilder = new ApiResponseBuilder();
+    console.info("Start calendar events handler");
+    try {
+      const config = Config.getInstance();
+      const parameterFetcher = new AwsParameterFetcher();
+      await config.init(parameterFetcher);
 
-  const auth = new GoogleAuthAdapter();
-  const token = {
-    accessToken: config.GOOGLE_ACCESS_TOKEN,
-    refreshToken: config.GOOGLE_REFRESH_TOKEN,
+      const auth = new GoogleAuthAdapter();
+      const token = {
+        accessToken: config.GOOGLE_ACCESS_TOKEN,
+        refreshToken: config.GOOGLE_REFRESH_TOKEN,
+      };
+      auth.setTokens(token);
+      const googleCalendarApi = new GoogleCalendarApiAdapter(auth);
+      const lineMessagingApiClient = new LineMessagingApiClient();
+
+      await new CalendarEventsNotifier(
+        googleCalendarApi,
+        lineMessagingApiClient
+      ).call();
+      console.info("End calendar events handler");
+
+      return responseBuilder.success(
+        "カレンダーイベントの通知処理が完了しました"
+      );
+    } catch (error) {
+      console.error("Error in calendar events handler:", error);
+      return responseBuilder.error(
+        "カレンダーイベントの通知処理中にエラーが発生しました"
+      );
+    }
   };
-  auth.setTokens(token);
-  const googleCalendarApi = new GoogleCalendarApiAdapter(auth);
-  const lineMessagingApiClient = new LineMessagingApiClient();
-
-  await new CalendarEventsNotifier(
-    googleCalendarApi,
-    lineMessagingApiClient
-  ).call();
-  console.info("End calendar events handler");
-};

--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -6,6 +6,7 @@ import type { LineWebhookEvent } from "../types/line-webhook-event";
 import { Config } from "../lib/config";
 import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { OAuthStateRepository } from "../lib/oauth-state-repository";
+import { ApiResponseBuilder } from "../lib/api-response-builder";
 
 /**
  * LINE Messaging APIのWebhookイベントを処理するLambda関数
@@ -15,6 +16,7 @@ import { OAuthStateRepository } from "../lib/oauth-state-repository";
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
+  const responseBuilder = new ApiResponseBuilder();
   try {
     console.debug({ event });
 
@@ -26,12 +28,9 @@ export const handler = async (
     // リクエストボディの検証
     if (!event.body) {
       console.warn("Request body is empty");
-      return {
+      return responseBuilder.error("Request body is required", {
         statusCode: 400,
-        body: JSON.stringify({
-          message: "Request body is required",
-        }),
-      };
+      });
     }
 
     // LINE Messaging APIのイベントをパース
@@ -41,12 +40,9 @@ export const handler = async (
       webhookEvent = body.events?.[0];
     } catch (error) {
       console.error("Failed to parse request body:", error);
-      return {
+      return responseBuilder.error("Invalid request body format", {
         statusCode: 400,
-        body: JSON.stringify({
-          message: "Invalid request body format",
-        }),
-      };
+      });
     }
 
     // 依存関係の初期化
@@ -63,22 +59,12 @@ export const handler = async (
     const result = await webhookUseCase.handleWebhookEvent(webhookEvent);
 
     // レスポンスの生成
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        message: result.message,
-      }),
-    };
+    return responseBuilder.success(result.message);
   } catch (error) {
     // エラーログの出力
     console.error("Unexpected error occurred:", error);
 
     // エラーレスポンスの生成
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        message: "Internal server error",
-      }),
-    };
+    return responseBuilder.error("Internal server error");
   }
 };

--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -28,9 +28,7 @@ export const handler = async (
     // リクエストボディの検証
     if (!event.body) {
       console.warn("Request body is empty");
-      return responseBuilder.error("Request body is required", {
-        statusCode: 400,
-      });
+      return responseBuilder.clientError("Request body is required");
     }
 
     // LINE Messaging APIのイベントをパース
@@ -40,9 +38,7 @@ export const handler = async (
       webhookEvent = body.events?.[0];
     } catch (error) {
       console.error("Failed to parse request body:", error);
-      return responseBuilder.error("Invalid request body format", {
-        statusCode: 400,
-      });
+      return responseBuilder.clientError("Invalid request body format");
     }
 
     // 依存関係の初期化
@@ -65,6 +61,6 @@ export const handler = async (
     console.error("Unexpected error occurred:", error);
 
     // エラーレスポンスの生成
-    return responseBuilder.error("Internal server error");
+    return responseBuilder.serverError("Internal server error");
   }
 };

--- a/src/handlers/oauth-callback-handler.ts
+++ b/src/handlers/oauth-callback-handler.ts
@@ -32,6 +32,8 @@ export const oauthCallbackHandler = async (
     return new ApiResponseBuilder().success(result.message);
   } catch (error) {
     console.error("Error in OAuth callback handler:", error);
-    return new ApiResponseBuilder().error("認証処理中にエラーが発生しました。");
+    return new ApiResponseBuilder().serverError(
+      "認証処理中にエラーが発生しました。"
+    );
   }
 };

--- a/src/handlers/oauth-callback-handler.ts
+++ b/src/handlers/oauth-callback-handler.ts
@@ -5,6 +5,7 @@ import { Config } from "../lib/config";
 import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
 import { TokenRepository } from "../lib/token-repository";
+import { ApiResponseBuilder } from "../lib/api-response-builder";
 
 export const oauthCallbackHandler = async (
   event: APIGatewayProxyEvent
@@ -28,17 +29,9 @@ export const oauthCallbackHandler = async (
     );
     const result = await useCase.execute(code, state);
 
-    return {
-      statusCode: 200,
-      body: JSON.stringify(result),
-    };
+    return new ApiResponseBuilder().success(result.message);
   } catch (error) {
     console.error("Error in OAuth callback handler:", error);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        message: "認証処理中にエラーが発生しました。",
-      }),
-    };
+    return new ApiResponseBuilder().error("認証処理中にエラーが発生しました。");
   }
 };

--- a/src/lib/api-response-builder.ts
+++ b/src/lib/api-response-builder.ts
@@ -22,7 +22,22 @@ export class ApiResponseBuilder implements Schema$ApiResponseBuilder {
     });
   }
 
-  error(message: string, options?: ApiResponseOptions): APIGatewayProxyResult {
+  clientError(
+    message: string,
+    options?: ApiResponseOptions
+  ): APIGatewayProxyResult {
+    return this.buildResponse({
+      statusCode: options?.statusCode ?? 400,
+      message,
+      data: options?.data,
+      headers: options?.headers,
+    });
+  }
+
+  serverError(
+    message: string,
+    options?: ApiResponseOptions
+  ): APIGatewayProxyResult {
     return this.buildResponse({
       statusCode: options?.statusCode ?? 500,
       message,

--- a/src/lib/api-response-builder.ts
+++ b/src/lib/api-response-builder.ts
@@ -1,0 +1,62 @@
+import type { APIGatewayProxyResult } from "aws-lambda";
+import type {
+  ApiResponseBody,
+  ApiResponseOptions,
+  Schema$ApiResponseBuilder,
+} from "../types/api-gateway-response";
+
+export class ApiResponseBuilder implements Schema$ApiResponseBuilder {
+  private readonly defaultHeaders = {
+    "Content-Type": "application/json; charset=utf-8",
+  };
+
+  success(
+    message: string,
+    options?: ApiResponseOptions
+  ): APIGatewayProxyResult {
+    return this.buildResponse({
+      statusCode: options?.statusCode ?? 200,
+      message,
+      data: options?.data,
+      headers: options?.headers,
+    });
+  }
+
+  error(message: string, options?: ApiResponseOptions): APIGatewayProxyResult {
+    return this.buildResponse({
+      statusCode: options?.statusCode ?? 500,
+      message,
+      data: options?.data,
+      headers: options?.headers,
+    });
+  }
+
+  private buildResponse({
+    statusCode,
+    message,
+    data,
+    headers,
+  }: {
+    statusCode: number;
+    message: string;
+    data?: unknown;
+    headers?: Record<string, string>;
+  }): APIGatewayProxyResult {
+    const body: ApiResponseBody = {
+      message,
+    };
+
+    if (data !== undefined) {
+      body.data = data;
+    }
+
+    return {
+      statusCode,
+      headers: {
+        ...this.defaultHeaders,
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    };
+  }
+}

--- a/src/types/api-gateway-response.d.ts
+++ b/src/types/api-gateway-response.d.ts
@@ -1,0 +1,23 @@
+import type { APIGatewayProxyResult } from "aws-lambda";
+
+export type ApiResponseBody = {
+  message: string;
+  data?: unknown;
+};
+
+export type ApiResponseOptions = {
+  statusCode?: number;
+  headers?: Record<string, string>;
+  data?: unknown;
+};
+
+export type Schema$ApiResponseBuilder = {
+  success: (
+    message: string,
+    options?: ApiResponseOptions
+  ) => APIGatewayProxyResult;
+  error: (
+    message: string,
+    options?: ApiResponseOptions
+  ) => APIGatewayProxyResult;
+};

--- a/src/types/api-gateway-response.d.ts
+++ b/src/types/api-gateway-response.d.ts
@@ -16,7 +16,11 @@ export type Schema$ApiResponseBuilder = {
     message: string,
     options?: ApiResponseOptions
   ) => APIGatewayProxyResult;
-  error: (
+  clientError: (
+    message: string,
+    options?: ApiResponseOptions
+  ) => APIGatewayProxyResult;
+  serverError: (
     message: string,
     options?: ApiResponseOptions
   ) => APIGatewayProxyResult;


### PR DESCRIPTION

- `ApiResponseBuilder`を追加して、API Gatewayへのレスポンスオブジェクト生成を共通化する
- レスポンスヘッダに`Content-Type: application/json; charset=utf-8`を追加
  - 認可完了時の文字化けを解消