### PR TITLE
GoogleのアクセストークンはDynamoDBから取得する

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ line-->|Webhook|apigw
 
 - LINE Messaging APIのための[チャネルアクセストークン](https://developers.line.biz/ja/docs/messaging-api/generate-json-web-token/)
   - 発行方法：https://zenn.dev/link/comments/ecfe0a7ca1d312
-- Googleアカウントのリフレッシュトークン
-  - 発行方法：https://zenn.dev/link/comments/8631c7f926eeaa
 
 ### デプロイ
 
@@ -127,7 +125,7 @@ bun run deploy
 ---|---|---
 line-schedule-reminder-google-client-id | GOOGLE_CLIENT_ID | Google Calendar APIのためのクライアントID
 line-schedule-reminder-google-client-secret | GOOGLE_CLIENT_SECRET | Google Calendar APIのためのクライアントシークレット 
-line-schedule-reminder-google-refresh-token | GOOGLE_REFRESH_TOKEN | Googleカレンダーにアクセスするためのリフレッシュトークン
+line-schedule-reminder-google-redirect-uri | GOOGLE_REDIRECT_URI | Googleで認可を得たときにリダイレクトされるURL
 line-schedule-reminder-line-channel-access-token | LINE_CHANNEL_ACCESS_TOKEN | LINEチャネルアクセストークン
 line-schedule-reminder-line-user-id | LINE_USER_ID | 通知先のLINEユーザーID
 

--- a/__tests__/handlers/calendar-events-handler.test.ts
+++ b/__tests__/handlers/calendar-events-handler.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import { calendarEventsHandler } from "../../src/handlers/calendar-events-handler";
+import { Config } from "../../src/lib/config";
+import { CalendarEventsUseCase } from "../../src/usecases/calendar-events-usecase";
+import { ParameterFetcherMock } from "../mocks/parameter-fetcher-mock";
+
+describe("calendarEventsHandler", () => {
+  let executeSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Configのモックをリセット
+    Config.getInstance().init(new ParameterFetcherMock());
+  });
+
+  afterEach(() => {
+    executeSpy?.mockRestore?.();
+  });
+
+  it("正常系: カレンダーイベントの通知処理が成功すること", async () => {
+    // Given
+    executeSpy = spyOn(
+      CalendarEventsUseCase.prototype,
+      "execute"
+    ).mockResolvedValue();
+
+    // When
+    const response = await calendarEventsHandler();
+
+    // Then
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      message: "カレンダーイベントの通知処理が完了しました",
+    });
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("異常系: カレンダーイベントの通知処理でエラーが発生した場合、500エラーを返すこと", async () => {
+    // Given
+    executeSpy = spyOn(
+      CalendarEventsUseCase.prototype,
+      "execute"
+    ).mockImplementation(() => Promise.reject(new Error("テストエラー")));
+
+    // When
+    const response = await calendarEventsHandler();
+
+    // Then
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({
+      message: "カレンダーイベントの通知処理中にエラーが発生しました",
+    });
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/handlers/calendar-events-handler.test.ts
+++ b/__tests__/handlers/calendar-events-handler.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
 import { calendarEventsHandler } from "../../src/handlers/calendar-events-handler";
-import { Config } from "../../src/lib/config";
+import { AwsParameterFetcher } from "../../src/lib/aws-parameter-fetcher";
 import { CalendarEventsUseCase } from "../../src/usecases/calendar-events-usecase";
-import { ParameterFetcherMock } from "../mocks/parameter-fetcher-mock";
 
 describe("calendarEventsHandler", () => {
   let executeSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    // Configのモックをリセット
-    Config.getInstance().init(new ParameterFetcherMock());
+    // AwsParameterFetcherのモック
+    spyOn(AwsParameterFetcher.prototype, "call").mockResolvedValue(
+      "mock-value"
+    );
   });
 
   afterEach(() => {

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -14,8 +14,6 @@ describe("Config", () => {
       process.env.GOOGLE_CLIENT_ID = "client-id";
       process.env.GOOGLE_CLIENT_SECRET = "client-secret";
       process.env.GOOGLE_REDIRECT_URI = "redirect-uri";
-      process.env.GOOGLE_ACCESS_TOKEN = "access-token";
-      process.env.GOOGLE_REFRESH_TOKEN = "refresh-token";
       process.env.LINE_CHANNEL_ACCESS_TOKEN = "channel-access-token";
       process.env.LINE_USER_ID = "line-user-id";
 
@@ -24,8 +22,6 @@ describe("Config", () => {
       expect(config.GOOGLE_CLIENT_ID).toBe("client-id");
       expect(config.GOOGLE_CLIENT_SECRET).toBe("client-secret");
       expect(config.GOOGLE_REDIRECT_URI).toBe("redirect-uri");
-      expect(config.GOOGLE_ACCESS_TOKEN).toBe("access-token");
-      expect(config.GOOGLE_REFRESH_TOKEN).toBe("refresh-token");
       expect(config.LINE_CHANNEL_ACCESS_TOKEN).toBe("channel-access-token");
       expect(config.LINE_USER_ID).toBe("line-user-id");
     });
@@ -36,8 +32,6 @@ describe("Config", () => {
       process.env.GOOGLE_CLIENT_ID = "";
       process.env.GOOGLE_CLIENT_SECRET = "";
       process.env.GOOGLE_REDIRECT_URI = "";
-      process.env.GOOGLE_ACCESS_TOKEN = "";
-      process.env.GOOGLE_REFRESH_TOKEN = "";
       process.env.LINE_CHANNEL_ACCESS_TOKEN = "";
       process.env.LINE_USER_ID = "";
 
@@ -46,8 +40,6 @@ describe("Config", () => {
       expect(config.GOOGLE_CLIENT_ID).toBe("mock-google-client-id");
       expect(config.GOOGLE_CLIENT_SECRET).toBe("mock-google-client-secret");
       expect(config.GOOGLE_REDIRECT_URI).toBe("mock-google-redirect-uri");
-      expect(config.GOOGLE_ACCESS_TOKEN).toBe("mock-google-access-token");
-      expect(config.GOOGLE_REFRESH_TOKEN).toBe("mock-google-refresh-token");
       expect(config.LINE_CHANNEL_ACCESS_TOKEN).toBe(
         "mock-line-channel-access-token"
       );

--- a/__tests__/mocks/mock-token-repository.ts
+++ b/__tests__/mocks/mock-token-repository.ts
@@ -11,4 +11,18 @@ export class MockTokenRepository implements Schema$TokenRepository {
   }
   async updateToken(token: UpdateToken): Promise<void> {}
   async deleteToken(userId: string): Promise<void> {}
+  async getAllTokens(): Promise<Token[]> {
+    return [
+      {
+        userId: "1",
+        accessToken: "accessToken",
+        refreshToken: "refreshToken",
+      },
+      {
+        userId: "2",
+        accessToken: "accessToken2",
+        refreshToken: "refreshToken2",
+      },
+    ];
+  }
 }

--- a/__tests__/usecases/calendar-events-usecase.test.ts
+++ b/__tests__/usecases/calendar-events-usecase.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, spyOn, afterEach } from "bun:test";
+import { CalendarEventsUseCase } from "../../src/usecases/calendar-events-usecase";
+import { MockTokenRepository } from "../mocks/mock-token-repository";
+import { LineMessagingApiClientMock } from "../mocks/line-messaging-api-client-mock";
+import { GoogleCalendarApiAdapter } from "../../src/google-calendar-api-adapter";
+import { CalendarEventsNotifier } from "../../src/calendar-events-notifier";
+
+describe("CalendarEventsUseCase", () => {
+  let notifierSpy: ReturnType<typeof spyOn>;
+  let fetchEventsSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    notifierSpy?.mockReset?.();
+    fetchEventsSpy?.mockReset?.();
+  });
+
+  describe("execute", () => {
+    it("すべてのユーザーのカレンダーイベントを通知できること", async () => {
+      // Given
+      const tokenRepository = new MockTokenRepository();
+      const lineMessagingApiClient = new LineMessagingApiClientMock();
+      const useCase = new CalendarEventsUseCase(
+        tokenRepository,
+        lineMessagingApiClient
+      );
+
+      // GoogleCalendarApiAdapterのモック
+      fetchEventsSpy = spyOn(
+        GoogleCalendarApiAdapter.prototype,
+        "fetchEvents"
+      ).mockResolvedValue([
+        {
+          summary: "Event 1",
+          start: { dateTime: "2024-01-01T00:00:00.000Z" },
+          end: { dateTime: "2024-01-01T01:00:00.000Z" },
+        },
+      ]);
+      notifierSpy = spyOn(CalendarEventsNotifier.prototype, "call");
+
+      // When
+      await useCase.execute();
+
+      // Then
+      expect(notifierSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("一部のユーザーでエラーが発生しても他のユーザーの処理は続行されること", async () => {
+      // Given
+      const tokenRepository = new MockTokenRepository();
+      const lineMessagingApiClient = new LineMessagingApiClientMock();
+      const useCase = new CalendarEventsUseCase(
+        tokenRepository,
+        lineMessagingApiClient
+      );
+
+      // GoogleCalendarApiAdapterのモック
+      fetchEventsSpy = spyOn(GoogleCalendarApiAdapter.prototype, "fetchEvents")
+        .mockImplementationOnce(() =>
+          Promise.reject(new Error("Error for user1"))
+        )
+        .mockResolvedValueOnce([
+          {
+            summary: "Event 1",
+            start: { dateTime: "2024-01-01T00:00:00.000Z" },
+            end: { dateTime: "2024-01-01T01:00:00.000Z" },
+          },
+        ]);
+      notifierSpy = spyOn(CalendarEventsNotifier.prototype, "call");
+
+      // When
+      await useCase.execute();
+
+      // Then
+      expect(notifierSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("トークンが存在しない場合は何も通知されないこと", async () => {
+      // Given
+      class EmptyTokenRepository extends MockTokenRepository {
+        async getAllTokens() {
+          return [];
+        }
+      }
+      const tokenRepository = new EmptyTokenRepository();
+      const lineMessagingApiClient = new LineMessagingApiClientMock();
+      const useCase = new CalendarEventsUseCase(
+        tokenRepository,
+        lineMessagingApiClient
+      );
+
+      // GoogleCalendarApiAdapterのモック
+      fetchEventsSpy = spyOn(
+        GoogleCalendarApiAdapter.prototype,
+        "fetchEvents"
+      ).mockResolvedValue([]);
+      notifierSpy = spyOn(CalendarEventsNotifier.prototype, "call");
+
+      // When
+      await useCase.execute();
+
+      // Then
+      expect(notifierSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -1,11 +1,8 @@
-import { CalendarEventsNotifier } from "../calendar-events-notifier";
-import { GoogleCalendarApiAdapter } from "../google-calendar-api-adapter";
-import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
-import { Config } from "../lib/config";
-import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
-import { LineMessagingApiClient } from "../line-messaging-api-client";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
 import type { APIGatewayProxyResult } from "aws-lambda";
+import { CalendarEventsUseCase } from "../usecases/calendar-events-usecase";
+import { Config } from "../lib/config";
+import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 
 export const calendarEventsHandler =
   async (): Promise<APIGatewayProxyResult> => {
@@ -16,19 +13,7 @@ export const calendarEventsHandler =
       const parameterFetcher = new AwsParameterFetcher();
       await config.init(parameterFetcher);
 
-      const auth = new GoogleAuthAdapter();
-      const token = {
-        accessToken: config.GOOGLE_ACCESS_TOKEN,
-        refreshToken: config.GOOGLE_REFRESH_TOKEN,
-      };
-      auth.setTokens(token);
-      const googleCalendarApi = new GoogleCalendarApiAdapter(auth);
-      const lineMessagingApiClient = new LineMessagingApiClient();
-
-      await new CalendarEventsNotifier(
-        googleCalendarApi,
-        lineMessagingApiClient
-      ).call();
+      await new CalendarEventsUseCase().execute();
       console.info("End calendar events handler");
 
       return responseBuilder.success(

--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -3,6 +3,8 @@ import type { APIGatewayProxyResult } from "aws-lambda";
 import { CalendarEventsUseCase } from "../usecases/calendar-events-usecase";
 import { Config } from "../lib/config";
 import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
+import { TokenRepository } from "../lib/token-repository";
+import { LineMessagingApiClient } from "../line-messaging-api-client";
 
 export const calendarEventsHandler =
   async (): Promise<APIGatewayProxyResult> => {
@@ -13,7 +15,12 @@ export const calendarEventsHandler =
       const parameterFetcher = new AwsParameterFetcher();
       await config.init(parameterFetcher);
 
-      await new CalendarEventsUseCase().execute();
+      const tokenRepository = new TokenRepository();
+      const lineMessagingApiClient = new LineMessagingApiClient();
+      await new CalendarEventsUseCase(
+        tokenRepository,
+        lineMessagingApiClient
+      ).execute();
       console.info("End calendar events handler");
 
       return responseBuilder.success(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,8 +8,6 @@ export class Config {
   GOOGLE_CLIENT_ID: string = "";
   GOOGLE_CLIENT_SECRET: string = "";
   GOOGLE_REDIRECT_URI: string = "";
-  GOOGLE_ACCESS_TOKEN: string = "";
-  GOOGLE_REFRESH_TOKEN: string = "";
   LINE_CHANNEL_ACCESS_TOKEN: string = "";
   LINE_USER_ID: string = "";
 
@@ -32,16 +30,12 @@ export class Config {
       google_client_id,
       google_client_secret,
       google_redirect_uri,
-      google_access_token,
-      google_refresh_token,
       line_channel_access_token,
       line_user_id,
     ] = await Promise.all([
       this.envOrParameter("google-client-id"),
       this.envOrParameter("google-client-secret"),
       this.envOrParameter("google-redirect-uri"),
-      this.envOrParameter("google-access-token"),
-      this.envOrParameter("google-refresh-token"),
       this.envOrParameter("line-channel-access-token"),
       this.envOrParameter("line-user-id"),
     ]);
@@ -49,8 +43,6 @@ export class Config {
     this.GOOGLE_CLIENT_ID = google_client_id;
     this.GOOGLE_CLIENT_SECRET = google_client_secret;
     this.GOOGLE_REDIRECT_URI = google_redirect_uri;
-    this.GOOGLE_ACCESS_TOKEN = google_access_token;
-    this.GOOGLE_REFRESH_TOKEN = google_refresh_token;
     this.LINE_CHANNEL_ACCESS_TOKEN = line_channel_access_token;
     this.LINE_USER_ID = line_user_id;
   }

--- a/src/lib/token-repository.ts
+++ b/src/lib/token-repository.ts
@@ -4,6 +4,8 @@ import {
   GetItemCommand,
   DeleteItemCommand,
   UpdateItemCommand,
+  QueryCommand,
+  ScanCommand,
 } from "@aws-sdk/client-dynamodb";
 import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
 import type {
@@ -109,5 +111,24 @@ export class TokenRepository implements Schema$TokenRepository {
     } catch (error) {
       console.error("Failed to delete token:", error);
     }
+  }
+
+  /**
+   * すべてのトークンを取得する
+   * @returns トークンの配列
+   */
+  async getAllTokens(): Promise<Token[]> {
+    const command = new ScanCommand({
+      TableName: this.tableName,
+    });
+    const result = await this.dynamoClient.send(command);
+    return (result.Items || []).map((item) => {
+      const unmarshalled = unmarshall(item);
+      return {
+        userId: unmarshalled.userId,
+        accessToken: unmarshalled.accessToken,
+        refreshToken: unmarshalled.refreshToken,
+      };
+    });
   }
 }

--- a/src/types/token-repository.d.ts
+++ b/src/types/token-repository.d.ts
@@ -15,4 +15,5 @@ export type Schema$TokenRepository = {
   getToken(userId: string): Promise<Token | null>;
   updateToken(token: UpdateToken): Promise<void>;
   deleteToken(userId: string): Promise<void>;
+  getAllTokens(): Promise<Token[]>;
 };

--- a/src/usecases/calendar-events-usecase.ts
+++ b/src/usecases/calendar-events-usecase.ts
@@ -1,0 +1,24 @@
+import { CalendarEventsNotifier } from "../calendar-events-notifier";
+import { GoogleCalendarApiAdapter } from "../google-calendar-api-adapter";
+import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
+import { LineMessagingApiClient } from "../line-messaging-api-client";
+import { Config } from "../lib/config";
+
+export class CalendarEventsUseCase {
+  async execute(): Promise<void> {
+    const config = Config.getInstance();
+    const auth = new GoogleAuthAdapter();
+    const token = {
+      accessToken: config.GOOGLE_ACCESS_TOKEN,
+      refreshToken: config.GOOGLE_REFRESH_TOKEN,
+    };
+    auth.setTokens(token);
+    const googleCalendarApi = new GoogleCalendarApiAdapter(auth);
+    const lineMessagingApiClient = new LineMessagingApiClient();
+
+    await new CalendarEventsNotifier(
+      googleCalendarApi,
+      lineMessagingApiClient
+    ).call();
+  }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -39,10 +39,12 @@ Resources:
               Action:
                 - "kms:Decrypt"
                 - "ssm:GetParameter"
+                - "dynamodb:Scan"
               Resource:
                 [
                   Fn::Sub: "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/ssm",
                   Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/schedule-line-reminder/*",
+                  !GetAtt OAuthTokensTable.Arn,
                 ]
       LoggingConfig:
         ApplicationLogLevel: DEBUG


### PR DESCRIPTION
GoogleアカウントのアクセストークンやリフレッシュトークンはDynamoDBの`OAuthTokens`テーブルから取得するように変更します。
今まではパラメータストアからトークンを取得していましたが、これでは複数ユーザーへ通知を送ることができません。
また、`calendar-events-handler.ts`からアプリケーションロジックを抽出し、`CalendarEvenetsUseCase`クラスを作りました。