### PR TITLE
終日の予定を表示できるようにする

### DIFF
--- a/__tests__/calendar-message-builder.test.ts
+++ b/__tests__/calendar-message-builder.test.ts
@@ -10,6 +10,7 @@ describe("CalendarMessageBuilder", () => {
           summary: "予定1",
           startDateTime: new Date("2021-01-01T00:00:00Z"),
           endDateTime: new Date("2021-01-01T01:00:00Z"),
+          isAllDay: false,
         },
       ];
       const builder = new CalendarMessageBuilder(events);
@@ -25,11 +26,13 @@ describe("CalendarMessageBuilder", () => {
           summary: "予定1",
           startDateTime: new Date("2021-01-01T00:00:00Z"),
           endDateTime: new Date("2021-01-01T01:00:00Z"),
+          isAllDay: false,
         },
         {
           summary: "予定2",
           startDateTime: new Date("2021-01-02T00:00:00Z"),
           endDateTime: new Date("2021-01-02T01:00:00Z"),
+          isAllDay: false,
         },
       ];
       const builder = new CalendarMessageBuilder(events, today);
@@ -41,6 +44,43 @@ describe("CalendarMessageBuilder", () => {
 
 2021/01/02
 09:00-10:00: 予定2
+
+2021/01/03
+予定なし
+
+2021/01/04
+予定なし
+
+2021/01/05
+予定なし
+
+2021/01/06
+予定なし
+
+2021/01/07
+予定なし`
+      );
+    });
+
+    it("終日の予定が記載されたメッセージが作成されること", () => {
+      const today = new Date("2020-12-31");
+      const events: Event[] = [
+        {
+          summary: "予定1",
+          startDateTime: new Date("2021-01-01"),
+          endDateTime: new Date("2021-01-02"),
+          isAllDay: true,
+        },
+      ];
+      const builder = new CalendarMessageBuilder(events, today);
+      const message = builder.build();
+      expect(message).toBe(
+        `明日から1週間の予定です。
+2021/01/01
+終日: 予定1
+
+2021/01/02
+予定なし
 
 2021/01/03
 予定なし

--- a/src/calendar-message-builder.ts
+++ b/src/calendar-message-builder.ts
@@ -68,6 +68,9 @@ export class CalendarMessageBuilder {
   }
 
   private formatEvent(event: Event): string {
+    if (event.isAllDay) {
+      return `終日: ${event.summary}`;
+    }
     const eventStartTime = event.startDateTime
       ? DateFormatter.jstHm(event.startDateTime)
       : "";

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -2,4 +2,5 @@ export type Event = {
   summary: string;
   startDateTime: Date | null;
   endDateTime: Date | null;
+  isAllDay: boolean;
 };

--- a/src/types/google-calendar-api-adapter.d.ts
+++ b/src/types/google-calendar-api-adapter.d.ts
@@ -1,9 +1,9 @@
 import { calendar_v3 } from "@googleapis/calendar";
 
+export type Schema$CalendarEvent = calendar_v3.Schema$Event;
+
 export type Schema$GoogleCalendarApiAdapter = {
-  fetchEvents: (
-    params: FetchEventsParams
-  ) => Promise<calendar_v3.Schema$Event[]>;
+  fetchEvents: (params: FetchEventsParams) => Promise<Schema$CalendarEvent[]>;
 };
 
 export type FetchEventsParams = {


### PR DESCRIPTION
resolve #46 

終日の予定を表示できるようにします。

出力例：

```
2025/05/30
終日: 旅行
```
