### PR TITLE
LINE Webhookの署名を検証する

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ line-schedule-reminder-google-client-id | GOOGLE_CLIENT_ID | Google Calendar API
 line-schedule-reminder-google-client-secret | GOOGLE_CLIENT_SECRET | Google Calendar APIのためのクライアントシークレット 
 line-schedule-reminder-google-redirect-uri | GOOGLE_REDIRECT_URI | Googleで認可を得たときにリダイレクトされるURL
 line-schedule-reminder-line-channel-access-token | LINE_CHANNEL_ACCESS_TOKEN | LINEチャネルアクセストークン
+line-schedule-reminder-line-channel-secret | LINE_CHANNEL_SECRET | LINEチャネルの署名キー
 
 ### 動作検証
 

--- a/__tests__/line-webhook-handler.test.ts
+++ b/__tests__/line-webhook-handler.test.ts
@@ -203,8 +203,8 @@ describe("Unit test for app handler", function () {
     });
   });
 
-  // FIXME: CIではAwsParameterFetcherがエラーになるため、テストをスキップ
-  it.skip("verifies successful response", async () => {
+  it("verifies successful response", async () => {
+    (validateSignature as any).mockReturnValue(true);
     const event: APIGatewayProxyEvent = {
       // This event is for the original test, ensure it uses the mocked config
       httpMethod: "post",
@@ -226,7 +226,7 @@ describe("Unit test for app handler", function () {
           },
         ],
       }),
-      headers: {},
+      headers: { "x-line-signature": "valid-signature" },
       isBase64Encoded: false,
       multiValueHeaders: {},
       multiValueQueryStringParameters: {},

--- a/__tests__/mocks/parameter-fetcher-mock.ts
+++ b/__tests__/mocks/parameter-fetcher-mock.ts
@@ -11,6 +11,8 @@ export class ParameterFetcherMock implements Schema$ParameterFetcher {
         return "mock-google-redirect-uri";
       case "line-channel-access-token":
         return "mock-line-channel-access-token";
+      case "line-channel-secret":
+        return "mock-line-channel-secret";
       default:
         throw new Error(`Unknown parameter name: ${name}`);
     }

--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -27,26 +27,24 @@ export const handler = async (
     await Config.getInstance().init(fetcher);
 
     // Signature validation
-    const signature = event.headers["x-line-signature"] || event.headers["X-Line-Signature"]; // Header names can be case-insensitive
+    const signature =
+      event.headers["x-line-signature"] || event.headers["X-Line-Signature"]; // Header names can be case-insensitive
     if (!signature) {
       console.warn("x-line-signature header is missing");
       return responseBuilder.clientError("x-line-signature header is required");
     }
 
     const channelSecret = Config.getInstance().LINE_CHANNEL_SECRET;
-    if (!event.body) { // event.body is used by validateSignature
+    if (!event.body) {
+      // event.body is used by validateSignature
       console.warn("Request body is empty, cannot validate signature");
-      return responseBuilder.clientError("Request body is required for signature validation");
+      return responseBuilder.clientError(
+        "Request body is required for signature validation"
+      );
     }
     if (!validateSignature(event.body, channelSecret, signature)) {
       console.warn("Signature validation failed");
       return responseBuilder.clientError("Signature validation failed");
-    }
-
-    // リクエストボディの検証
-    if (!event.body) {
-      console.warn("Request body is empty");
-      return responseBuilder.clientError("Request body is required");
     }
 
     // LINE Messaging APIのイベントをパース

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,6 +9,7 @@ export class Config {
   GOOGLE_CLIENT_SECRET: string = "";
   GOOGLE_REDIRECT_URI: string = "";
   LINE_CHANNEL_ACCESS_TOKEN: string = "";
+  LINE_CHANNEL_SECRET: string = "";
 
   static getInstance() {
     if (!this.instance) {
@@ -30,17 +31,20 @@ export class Config {
       google_client_secret,
       google_redirect_uri,
       line_channel_access_token,
+      line_channel_secret,
     ] = await Promise.all([
       this.envOrParameter("google-client-id"),
       this.envOrParameter("google-client-secret"),
       this.envOrParameter("google-redirect-uri"),
       this.envOrParameter("line-channel-access-token"),
+      this.envOrParameter("line-channel-secret"),
     ]);
 
     this.GOOGLE_CLIENT_ID = google_client_id;
     this.GOOGLE_CLIENT_SECRET = google_client_secret;
     this.GOOGLE_REDIRECT_URI = google_redirect_uri;
     this.LINE_CHANNEL_ACCESS_TOKEN = line_channel_access_token;
+    this.LINE_CHANNEL_SECRET = line_channel_secret;
   }
 
   private async envOrParameter(name: string): Promise<string> {


### PR DESCRIPTION
resolve #26 

LINE PlatformからWebhookリクエストを受けたときに署名を検証します。

- これはLINE Messaging APIのドキュメントでも検証することを指示されています。
  - > ボットサーバーが受信したHTTP POSTリクエストは、LINEプラットフォームから送信されていない危険なリクエストの可能性があります。必ず署名を検証してから、Webhookイベントオブジェクトを処理してください。
  - https://developers.line.biz/ja/docs/messaging-api/receiving-messages/#verify-signature
- 署名自体は LINEのSDKの`validateSignature`関数を利用します。
- 検証の際にチャネルの署名キーが必要になるため、パラメータストアもしくは環境変数にセットする必要があります。

---
This commit introduces signature validation for incoming LINE webhook requests.

- Added `validateSignature` from `@line/bot-sdk` to `src/handlers/line-webhook-handler.ts`.
- Updated `Config` class to fetch and provide the LINE channel secret.
- Implemented logic in `line-webhook-handler.ts` to:
    - Retrieve the `x-line-signature` header.
    - Call `validateSignature` with the request body, channel secret, and signature.
    - Return a 400 Bad Request response if validation fails or the header is missing.
- Added unit tests in `__tests__/line-webhook-handler.test.ts` to cover:
    - Valid signatures.
    - Invalid signatures.
    - Missing `x-line-signature` header.
    - Empty request body.

This ensures that only legitimate requests from the LINE Platform are processed, enhancing the security of the webhook.