### PR TITLE
ブロックされたときにトークン情報を削除する

### DIFF
--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -7,6 +7,7 @@ import type { LineWebhookEvent } from "../types/line-webhook-event";
 import { Config } from "../lib/config";
 import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { OAuthStateRepository } from "../lib/oauth-state-repository";
+import { TokenRepository } from "../lib/token-repository";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
 
 /**
@@ -61,10 +62,12 @@ export const handler = async (
     const lineClient = new LineMessagingApiClient();
     const googleAuth = new GoogleAuthAdapter();
     const stateRepository = new OAuthStateRepository();
+    const tokenRepository = new TokenRepository();
     const webhookUseCase = new LineWebhookUseCase(
       lineClient,
       googleAuth,
-      stateRepository
+      stateRepository,
+      tokenRepository
     );
 
     // Webhookイベントの処理

--- a/src/types/line-webhook-event.d.ts
+++ b/src/types/line-webhook-event.d.ts
@@ -2,18 +2,20 @@
  * LINE Messaging APIから受け取るWebhookイベントの型定義
  * 参考: https://developers.line.biz/ja/reference/messaging-api/#webhook-event-objects
  */
-export type LineWebhookEvent = {
+
+/** メッセージイベントの型定義 */
+type MessageEvent = {
   /** イベントの種類 */
-  type: "message" | "unfollow";
-  /** メッセージの内容（typeがmessageの場合のみ） */
-  message?: {
+  type: "message";
+  /** メッセージの内容 */
+  message: {
     /** メッセージの種類。テキストメッセージの場合は "text" */
     type: "text";
     /** メッセージのテキスト */
     text: string;
   };
-  /** リプライトークン。メッセージに返信する際に使用（typeがmessageの場合のみ） */
-  replyToken?: string;
+  /** リプライトークン。メッセージに返信する際に使用 */
+  replyToken: string;
   /** イベントの送信元情報 */
   source: {
     /** 送信元の種類。ユーザーからのメッセージの場合は "user" */
@@ -26,3 +28,23 @@ export type LineWebhookEvent = {
   /** チャネルの状態。通常は "active" */
   mode: "active";
 };
+
+/** 友だち解除イベントの型定義 */
+type UnfollowEvent = {
+  /** イベントの種類 */
+  type: "unfollow";
+  /** イベントの送信元情報 */
+  source: {
+    /** 送信元の種類。ユーザーからのメッセージの場合は "user" */
+    type: "user";
+    /** 送信元のユーザーID */
+    userId: string;
+  };
+  /** イベントの発生時刻（UNIX時間） */
+  timestamp: number;
+  /** チャネルの状態。通常は "active" */
+  mode: "active";
+};
+
+/** LINE Messaging APIから受け取るWebhookイベントの型定義 */
+export type LineWebhookEvent = MessageEvent | UnfollowEvent;

--- a/src/types/line-webhook-event.d.ts
+++ b/src/types/line-webhook-event.d.ts
@@ -3,17 +3,17 @@
  * 参考: https://developers.line.biz/ja/reference/messaging-api/#webhook-event-objects
  */
 export type LineWebhookEvent = {
-  /** イベントの種類。テキストメッセージの場合は "message" */
-  type: "message";
-  /** メッセージの内容 */
-  message: {
+  /** イベントの種類 */
+  type: "message" | "unfollow";
+  /** メッセージの内容（typeがmessageの場合のみ） */
+  message?: {
     /** メッセージの種類。テキストメッセージの場合は "text" */
     type: "text";
     /** メッセージのテキスト */
     text: string;
   };
-  /** リプライトークン。メッセージに返信する際に使用 */
-  replyToken: string;
+  /** リプライトークン。メッセージに返信する際に使用（typeがmessageの場合のみ） */
+  replyToken?: string;
   /** イベントの送信元情報 */
   source: {
     /** 送信元の種類。ユーザーからのメッセージの場合は "user" */

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -3,12 +3,14 @@ import type { Schema$GoogleAuth } from "../types/google-auth";
 import type { WebhookUseCaseResult } from "../types/webhook-usecase-result";
 import type { LineWebhookEvent } from "../types/line-webhook-event";
 import type { Schema$OAuthStateRepository } from "../types/oauth-state-repository";
+import type { Schema$TokenRepository } from "../types/token-repository";
 
 export class LineWebhookUseCase {
   constructor(
     private readonly lineClient: Schema$LineMessagingApiClient,
     private readonly googleAuth: Schema$GoogleAuth,
-    private readonly stateRepository: Schema$OAuthStateRepository
+    private readonly stateRepository: Schema$OAuthStateRepository,
+    private readonly tokenRepository: Schema$TokenRepository
   ) {}
 
   async handleWebhookEvent(
@@ -19,6 +21,22 @@ export class LineWebhookUseCase {
         success: true,
         message: "no event",
       };
+    }
+
+    if (webhookEvent.type === "unfollow") {
+      try {
+        await this.tokenRepository.deleteToken(webhookEvent.source.userId);
+        return {
+          success: true,
+          message: "トークン情報を削除しました",
+        };
+      } catch (error) {
+        console.error("Failed to delete token:", error);
+        return {
+          success: false,
+          message: "トークン情報の削除に失敗しました",
+        };
+      }
     }
 
     if (

--- a/template.yaml
+++ b/template.yaml
@@ -92,11 +92,13 @@ Resources:
                 - "kms:Decrypt"
                 - "ssm:GetParameter"
                 - "dynamodb:PutItem"
+                - "dynamodb:DeleteItem"
               Resource:
                 [
                   Fn::Sub: "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/ssm",
                   Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/schedule-line-reminder/*",
                   !GetAtt OAuthStateTable.Arn,
+                  !GetAtt OAuthTokensTable.Arn,
                 ]
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild


### PR DESCRIPTION
resolve #38 

`unfollow`イベントをトリガーにして、トークン情報を削除する。
https://developers.line.biz/ja/reference/messaging-api/#unfollow-event

イベントオブジェクトの例：
```json
{
  "destination": "xxxxxxxxxx",
  "events": [
    {
      "type": "unfollow",
      "mode": "active",
      "timestamp": 1462629479859,
      "source": {
        "type": "user",
        "userId": "U4af4980629..."
      },
      "webhookEventId": "01FZ74A0TDDPYRVKNK77XKC3ZR",
      "deliveryContext": {
        "isRedelivery": false
      }
    }
  ]
}
```