### PR TITLE
CloudWatch Alarmを必要なもののみに絞る

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -189,6 +189,9 @@ Resources:
               AlarmMetrics:
                 - MetricName: SystemErrors
                   AlarmThreshold: 1
+                  EvaluationPeriods: 2
+                  Period: 300
+                  Statistic: Sum
                 - MetricName: UserErrors
                   AlarmThreshold: 1
         - ComponentName: !Sub ${AWS::StackName}-oauth-tokens
@@ -199,6 +202,9 @@ Resources:
               AlarmMetrics:
                 - MetricName: SystemErrors
                   AlarmThreshold: 1
+                  EvaluationPeriods: 2
+                  Period: 300
+                  Statistic: Sum
                 - MetricName: UserErrors
                   AlarmThreshold: 1
   # OAuth stateパラメータを管理するDynamoDBテーブル

--- a/template.yaml
+++ b/template.yaml
@@ -203,6 +203,16 @@ Resources:
                   EvaluationPeriods: 2
                   Period: 300
                   Statistic: Sum
+        - ComponentName: !Sub ${AWS::StackName}-application
+          Tier: CUSTOM
+          CustomComponentConfiguration:
+            ConfigurationDetails:
+              AlarmMetrics:
+                - MetricName: UserErrors
+                  AlarmThreshold: 1
+                  EvaluationPeriods: 2
+                  Period: 300
+                  Statistic: Sum
   # OAuth stateパラメータを管理するDynamoDBテーブル
   # stateパラメータを一時的に保存し、TTLで自動的に削除される
   OAuthStateTable:

--- a/template.yaml
+++ b/template.yaml
@@ -189,14 +189,8 @@ Resources:
               AlarmMetrics:
                 - MetricName: SystemErrors
                   AlarmThreshold: 1
-                - MetricName: ThrottledRequests
-                  AlarmThreshold: 1
                 - MetricName: UserErrors
                   AlarmThreshold: 1
-              Logs:
-                - LogGroupName: !Sub /aws/dynamodb/${AWS::StackName}-oauth-state
-                  LogPath: /aws/dynamodb
-                  LogType: DYNAMODB
         - ComponentName: !Sub ${AWS::StackName}-oauth-tokens
           ComponentARN: !GetAtt OAuthTokensTable.Arn
           Tier: CUSTOM
@@ -205,14 +199,8 @@ Resources:
               AlarmMetrics:
                 - MetricName: SystemErrors
                   AlarmThreshold: 1
-                - MetricName: ThrottledRequests
-                  AlarmThreshold: 1
                 - MetricName: UserErrors
                   AlarmThreshold: 1
-              Logs:
-                - LogGroupName: !Sub /aws/dynamodb/${AWS::StackName}-oauth-tokens
-                  LogPath: /aws/dynamodb
-                  LogType: DYNAMODB
   # OAuth stateパラメータを管理するDynamoDBテーブル
   # stateパラメータを一時的に保存し、TTLで自動的に削除される
   OAuthStateTable:

--- a/template.yaml
+++ b/template.yaml
@@ -181,6 +181,30 @@ Resources:
         Ref: ApplicationResourceGroup
       AutoConfigurationEnabled: "true"
       ComponentMonitoringSettings:
+        - ComponentARN: !GetAtt CalendarEventsNotifier.Arn
+          Tier: CUSTOM
+          ComponentConfigurationMode: CUSTOM
+          CustomComponentConfiguration:
+            ConfigurationDetails:
+              AlarmMetrics:
+                - AlarmMetricName: Errors
+                - AlarmMetricName: Duration
+        - ComponentARN: !GetAtt WebhookFunction.Arn
+          Tier: CUSTOM
+          ComponentConfigurationMode: CUSTOM
+          CustomComponentConfiguration:
+            ConfigurationDetails:
+              AlarmMetrics:
+                - AlarmMetricName: Errors
+                - AlarmMetricName: Duration
+        - ComponentARN: !GetAtt OAuthCallbackFunction.Arn
+          Tier: CUSTOM
+          ComponentConfigurationMode: CUSTOM
+          CustomComponentConfiguration:
+            ConfigurationDetails:
+              AlarmMetrics:
+                - AlarmMetricName: Errors
+                - AlarmMetricName: Duration
         - ComponentARN: !GetAtt OAuthStateTable.Arn
           Tier: CUSTOM
           ComponentConfigurationMode: CUSTOM

--- a/template.yaml
+++ b/template.yaml
@@ -180,6 +180,39 @@ Resources:
       ResourceGroupName:
         Ref: ApplicationResourceGroup
       AutoConfigurationEnabled: "true"
+      ComponentMonitoringSettings:
+        - ComponentName: !Sub ${AWS::StackName}-oauth-state
+          ComponentARN: !GetAtt OAuthStateTable.Arn
+          Tier: CUSTOM
+          CustomComponentConfiguration:
+            ConfigurationDetails:
+              AlarmMetrics:
+                - MetricName: SystemErrors
+                  AlarmThreshold: 1
+                - MetricName: ThrottledRequests
+                  AlarmThreshold: 1
+                - MetricName: UserErrors
+                  AlarmThreshold: 1
+              Logs:
+                - LogGroupName: !Sub /aws/dynamodb/${AWS::StackName}-oauth-state
+                  LogPath: /aws/dynamodb
+                  LogType: DYNAMODB
+        - ComponentName: !Sub ${AWS::StackName}-oauth-tokens
+          ComponentARN: !GetAtt OAuthTokensTable.Arn
+          Tier: CUSTOM
+          CustomComponentConfiguration:
+            ConfigurationDetails:
+              AlarmMetrics:
+                - MetricName: SystemErrors
+                  AlarmThreshold: 1
+                - MetricName: ThrottledRequests
+                  AlarmThreshold: 1
+                - MetricName: UserErrors
+                  AlarmThreshold: 1
+              Logs:
+                - LogGroupName: !Sub /aws/dynamodb/${AWS::StackName}-oauth-tokens
+                  LogPath: /aws/dynamodb
+                  LogType: DYNAMODB
   # OAuth stateパラメータを管理するDynamoDBテーブル
   # stateパラメータを一時的に保存し、TTLで自動的に削除される
   OAuthStateTable:

--- a/template.yaml
+++ b/template.yaml
@@ -192,8 +192,6 @@ Resources:
                   EvaluationPeriods: 2
                   Period: 300
                   Statistic: Sum
-                - MetricName: UserErrors
-                  AlarmThreshold: 1
         - ComponentName: !Sub ${AWS::StackName}-oauth-tokens
           ComponentARN: !GetAtt OAuthTokensTable.Arn
           Tier: CUSTOM
@@ -205,8 +203,6 @@ Resources:
                   EvaluationPeriods: 2
                   Period: 300
                   Statistic: Sum
-                - MetricName: UserErrors
-                  AlarmThreshold: 1
   # OAuth stateパラメータを管理するDynamoDBテーブル
   # stateパラメータを一時的に保存し、TTLで自動的に削除される
   OAuthStateTable:

--- a/template.yaml
+++ b/template.yaml
@@ -181,38 +181,20 @@ Resources:
         Ref: ApplicationResourceGroup
       AutoConfigurationEnabled: "true"
       ComponentMonitoringSettings:
-        - ComponentName: !Sub ${AWS::StackName}-oauth-state
-          ComponentARN: !GetAtt OAuthStateTable.Arn
+        - ComponentARN: !GetAtt OAuthStateTable.Arn
           Tier: CUSTOM
+          ComponentConfigurationMode: CUSTOM
           CustomComponentConfiguration:
             ConfigurationDetails:
               AlarmMetrics:
-                - MetricName: SystemErrors
-                  AlarmThreshold: 1
-                  EvaluationPeriods: 2
-                  Period: 300
-                  Statistic: Sum
-        - ComponentName: !Sub ${AWS::StackName}-oauth-tokens
-          ComponentARN: !GetAtt OAuthTokensTable.Arn
+                - AlarmMetricName: SystemErrors
+        - ComponentARN: !GetAtt OAuthTokensTable.Arn
           Tier: CUSTOM
+          ComponentConfigurationMode: CUSTOM
           CustomComponentConfiguration:
             ConfigurationDetails:
               AlarmMetrics:
-                - MetricName: SystemErrors
-                  AlarmThreshold: 1
-                  EvaluationPeriods: 2
-                  Period: 300
-                  Statistic: Sum
-        - ComponentName: !Sub ${AWS::StackName}-application
-          Tier: CUSTOM
-          CustomComponentConfiguration:
-            ConfigurationDetails:
-              AlarmMetrics:
-                - MetricName: UserErrors
-                  AlarmThreshold: 1
-                  EvaluationPeriods: 2
-                  Period: 300
-                  Statistic: Sum
+                - AlarmMetricName: SystemErrors
   # OAuth stateパラメータを管理するDynamoDBテーブル
   # stateパラメータを一時的に保存し、TTLで自動的に削除される
   OAuthStateTable:


### PR DESCRIPTION
resolve #52 

CloudWatch Alarmの無料枠が10個までなので、本当に必要なアラームのみに絞る

- DynamoDB
  - SystemError
- Lambda
  - Errors
  - Duration

参考：

- [AWS Lambda function - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/appinsights-metrics-lambda.html)
- [Amazon DynamoDB table - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/appinsights-metrics-dyanamodb.html)