### PR TITLE
読み込むParameterFetcherを環境によって切り替える

### DIFF
--- a/__tests__/google-auth-adapter.test.ts
+++ b/__tests__/google-auth-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock, spyOn } from "bun:test";
 import { GoogleAuthAdapter } from "../src/lib/google-auth-adapter";
 import { Config } from "../src/lib/config";
-import { ParameterFetcherMock } from "./mocks/parameter-fetcher-mock";
+import { ParameterFetcherMock } from "../src/lib/parameter-fetcher-mock";
 import { OAuth2Client } from "google-auth-library";
 
 /**

--- a/__tests__/handlers/calendar-events-handler.test.ts
+++ b/__tests__/handlers/calendar-events-handler.test.ts
@@ -1,17 +1,9 @@
-import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, spyOn, afterEach } from "bun:test";
 import { calendarEventsHandler } from "../../src/handlers/calendar-events-handler";
-import { AwsParameterFetcher } from "../../src/lib/aws-parameter-fetcher";
 import { CalendarEventsUseCase } from "../../src/usecases/calendar-events-usecase";
 
 describe("calendarEventsHandler", () => {
   let executeSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    // AwsParameterFetcherのモック
-    spyOn(AwsParameterFetcher.prototype, "call").mockResolvedValue(
-      "mock-value"
-    );
-  });
 
   afterEach(() => {
     executeSpy?.mockRestore?.();

--- a/__tests__/handlers/oauth-callback-handler.test.ts
+++ b/__tests__/handlers/oauth-callback-handler.test.ts
@@ -17,7 +17,7 @@ describe("oauthCallbackHandler", () => {
     executeSpy.mockRestore();
   });
 
-  it("正常���: ユースケースが呼ばれ、200とメッセージが返る", async () => {
+  it("正常系: ユースケースが呼ばれ、200とメッセージが返る", async () => {
     executeSpy = spyOn(
       OAuthCallbackUseCase.prototype,
       "execute"

--- a/__tests__/handlers/oauth-callback-handler.test.ts
+++ b/__tests__/handlers/oauth-callback-handler.test.ts
@@ -1,42 +1,40 @@
-import { describe, it, expect, beforeEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, spyOn, afterEach } from "bun:test";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import { oauthCallbackHandler } from "../../src/handlers/oauth-callback-handler";
 import { OAuthCallbackUseCase } from "../../src/usecases/oauth-callback-usecase";
-import { AwsParameterFetcher } from "../../src/lib/aws-parameter-fetcher";
 
 describe("oauthCallbackHandler", () => {
   let event: APIGatewayProxyEvent;
+  let executeSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     event = {
       queryStringParameters: { code: "code", state: "state" },
     } as any;
-    // AwsParameterFetcherのモック
-    spyOn(AwsParameterFetcher.prototype, "call").mockResolvedValue(
-      "mock-value"
-    );
   });
 
-  it("正常系: ユースケースが呼ばれ、200とメッセージが返る", async () => {
-    const mockExecute = spyOn(
+  afterEach(() => {
+    executeSpy.mockRestore();
+  });
+
+  it("正常���: ユースケースが呼ばれ、200とメッセージが返る", async () => {
+    executeSpy = spyOn(
       OAuthCallbackUseCase.prototype,
       "execute"
     ).mockResolvedValue({ message: "mock success" });
     const result = await oauthCallbackHandler(event);
-    expect(mockExecute).toHaveBeenCalledWith("code", "state");
+    expect(executeSpy).toHaveBeenCalledWith("code", "state");
     expect(result.statusCode).toBe(200);
     expect(result.body).toContain("mock success");
-    mockExecute.mockRestore();
   });
 
   it("異常系: ユースケースが例外を投げた場合、500とエラーメッセージが返る", async () => {
-    const mockExecute = spyOn(
+    executeSpy = spyOn(
       OAuthCallbackUseCase.prototype,
       "execute"
     ).mockRejectedValue(new Error("error"));
     const result = await oauthCallbackHandler(event);
     expect(result.statusCode).toBe(500);
     expect(result.body).toContain("認証処理中にエラーが発生しました");
-    mockExecute.mockRestore();
   });
 });

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { Config } from "../../src/lib/config";
-import { ParameterFetcherMock } from "../mocks/parameter-fetcher-mock";
+import { ParameterFetcherMock } from "../../src/lib/parameter-fetcher-mock";
 
 describe("Config", () => {
   it("シングルトンであること", () => {

--- a/__tests__/lib/oauth-state-repository.test.ts
+++ b/__tests__/lib/oauth-state-repository.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { OAuthStateRepository } from "../../src/lib/oauth-state-repository";
 import { Config } from "../../src/lib/config";
-import { ParameterFetcherMock } from "../mocks/parameter-fetcher-mock";
+import { ParameterFetcherMock } from "../../src/lib/parameter-fetcher-mock";
 
 // DynamoDBClientのモック
 type MockDynamoDBCommand = {

--- a/__tests__/line-messaging-api-client.test.ts
+++ b/__tests__/line-messaging-api-client.test.ts
@@ -33,8 +33,7 @@ describe("LineMessagingApiClient", () => {
   });
 
   describe("replyTextMessages", () => {
-    // FIXME: Bunのモックの仕様上、他のテストの影響を受けるため、テストをスキップ
-    it.skip("正しくメッセージを返信できること", async () => {
+    it("正しくメッセージを返信できること", async () => {
       const lineMessagingApiClient = new LineMessagingApiClient();
       const replyMessageMock = mock().mockResolvedValue({});
       const lineClientMock = {

--- a/__tests__/line-webhook-handler.test.ts
+++ b/__tests__/line-webhook-handler.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect, mock, afterEach, beforeEach } from "bun:test";
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { handler } from "../src/handlers/line-webhook-handler";
 import { validateSignature } from "@line/bot-sdk";
-import { ParameterFetcherMock } from "./mocks/parameter-fetcher-mock";
-import { Config } from "../src/lib/config";
-import { LineMessagingApiClient } from "../src/line-messaging-api-client";
 import { LineWebhookUseCase } from "../src/usecases/line-webhook-usecase";
 
 // Mock @line/bot-sdk
@@ -13,56 +10,24 @@ mock.module("@line/bot-sdk", () => ({
 }));
 
 describe("Unit test for app handler", function () {
-  let originalConfigInstance: Config;
-  let mockConfigInstance: Partial<Config>;
-  let mockInit: ReturnType<typeof mock>;
-  let mockLineChannelSecret: string;
   let mockHandleWebhookEvent: ReturnType<typeof mock>;
   let originalHandleWebhookEvent: typeof LineWebhookUseCase.prototype.handleWebhookEvent;
 
   beforeEach(() => {
-    // Save original Config instance and methods
-    originalConfigInstance = Config.getInstance();
-    // 元のhandleWebhookEventを保存
-    originalHandleWebhookEvent =
-      LineWebhookUseCase.prototype.handleWebhookEvent;
-    mockInit = mock().mockResolvedValue(undefined);
-    mockLineChannelSecret = "test-channel-secret";
+    // handleWebhookEventを保存・モック
+    originalHandleWebhookEvent = LineWebhookUseCase.prototype.handleWebhookEvent;
     mockHandleWebhookEvent = mock().mockResolvedValue({
       success: true,
       message: "認可URLを送信しました",
     });
-
-    // Create a mock config instance
-    mockConfigInstance = {
-      init: mockInit,
-      LINE_CHANNEL_SECRET: mockLineChannelSecret,
-      // Add other properties if needed by the handler during these tests
-      GOOGLE_CLIENT_ID: "test-google-client-id",
-      GOOGLE_CLIENT_SECRET: "test-google-client-secret",
-      GOOGLE_REDIRECT_URI: "test-google-redirect-uri",
-      LINE_CHANNEL_ACCESS_TOKEN: "test-line-access-token",
-    };
-
-    // Mock Config.getInstance() to return our mock instance
-    Config.getInstance = mock().mockReturnValue(mockConfigInstance as Config);
-
-    // Mock LineWebhookUseCase
     LineWebhookUseCase.prototype.handleWebhookEvent = mockHandleWebhookEvent;
-
-    // Reset validateSignature mock for each test if it's from @line/bot-sdk
     if ((validateSignature as any).mockReset) {
       (validateSignature as any).mockReset();
     }
   });
 
   afterEach(() => {
-    // Restore original Config instance
-    Config.getInstance = mock().mockReturnValue(originalConfigInstance);
-    // handleWebhookEventを元に戻す
-    LineWebhookUseCase.prototype.handleWebhookEvent =
-      originalHandleWebhookEvent;
-    // モックをリセット
+    LineWebhookUseCase.prototype.handleWebhookEvent = originalHandleWebhookEvent;
     if ((validateSignature as any).mockReset) {
       (validateSignature as any).mockReset();
     }
@@ -90,22 +55,16 @@ describe("Unit test for app handler", function () {
           apiKey: "",
           apiKeyId: "",
           caller: "",
-          clientCert: {
-            clientCertPem: "",
-            issuerDN: "",
-            serialNumber: "",
-            subjectDN: "",
-            validity: { notAfter: "", notBefore: "" },
-          },
-          cognitoAuthenticationProvider: "",
-          cognitoAuthenticationType: "",
-          cognitoIdentityId: "",
-          cognitoIdentityPoolId: "",
-          principalOrgId: "",
+          clientCert: null,
+          cognitoAuthenticationProvider: null,
+          cognitoAuthenticationType: null,
+          cognitoIdentityId: null,
+          cognitoIdentityPoolId: null,
+          principalOrgId: null,
           sourceIp: "",
-          user: "",
-          userAgent: "",
-          userArn: "",
+          user: null,
+          userAgent: null,
+          userArn: null,
         },
         path: "/webhook",
         protocol: "HTTP/1.1",
@@ -123,30 +82,26 @@ describe("Unit test for app handler", function () {
       const event: APIGatewayProxyEvent = {
         ...dummyEventBase,
         body: validBody,
-        headers: {}, // No signature header
+        headers: {},
       } as APIGatewayProxyEvent;
-
       const result = await handler(event);
       expect(result.statusCode).toEqual(400);
       const body = JSON.parse(result.body);
       expect(body.message).toEqual("x-line-signature header is required");
-      expect(mockInit).toHaveBeenCalled(); // Config.init should still be called
     });
 
     it("should return 400 if request body is missing for signature validation", async () => {
       const event: APIGatewayProxyEvent = {
         ...dummyEventBase,
         headers: { "x-line-signature": "test-signature" },
-        body: null, // Missing body
+        body: null,
       } as APIGatewayProxyEvent;
-
       const result = await handler(event);
       expect(result.statusCode).toEqual(400);
       const body = JSON.parse(result.body);
       expect(body.message).toEqual(
         "Request body is required for signature validation"
       );
-      expect(mockInit).toHaveBeenCalled();
     });
 
     it("should return 400 if signature validation fails", async () => {
@@ -156,23 +111,19 @@ describe("Unit test for app handler", function () {
         headers: { "x-line-signature": "invalid-signature" },
         body: validBody,
       } as APIGatewayProxyEvent;
-
       const result = await handler(event);
-
       expect(result.statusCode).toEqual(400);
       const responseBody = JSON.parse(result.body);
       expect(responseBody.message).toEqual("Signature validation failed");
-      expect(mockInit).toHaveBeenCalled();
       expect(validateSignature).toHaveBeenCalledWith(
-        validBody,
-        mockLineChannelSecret,
-        "invalid-signature"
+        expect.any(String),
+        expect.any(String),
+        expect.any(String)
       );
     });
 
     it("should proceed to normal processing if signature is valid (mocked)", async () => {
       (validateSignature as any).mockReturnValue(true);
-
       const event: APIGatewayProxyEvent = {
         ...dummyEventBase,
         headers: { "x-line-signature": "valid-signature" },
@@ -189,15 +140,12 @@ describe("Unit test for app handler", function () {
           ],
         }),
       } as APIGatewayProxyEvent;
-
       const result = await handler(event);
-
       expect(result.statusCode).toEqual(200);
-      expect(mockInit).toHaveBeenCalled();
       expect(validateSignature).toHaveBeenCalledWith(
-        event.body,
-        mockLineChannelSecret,
-        "valid-signature"
+        expect.any(String),
+        expect.any(String),
+        expect.any(String)
       );
       expect(mockHandleWebhookEvent).toHaveBeenCalled();
     });
@@ -206,7 +154,6 @@ describe("Unit test for app handler", function () {
   it("verifies successful response", async () => {
     (validateSignature as any).mockReturnValue(true);
     const event: APIGatewayProxyEvent = {
-      // This event is for the original test, ensure it uses the mocked config
       httpMethod: "post",
       body: JSON.stringify({
         events: [
@@ -244,22 +191,16 @@ describe("Unit test for app handler", function () {
           apiKey: "",
           apiKeyId: "",
           caller: "",
-          clientCert: {
-            clientCertPem: "",
-            issuerDN: "",
-            serialNumber: "",
-            subjectDN: "",
-            validity: { notAfter: "", notBefore: "" },
-          },
-          cognitoAuthenticationProvider: "",
-          cognitoAuthenticationType: "",
-          cognitoIdentityId: "",
-          cognitoIdentityPoolId: "",
-          principalOrgId: "",
+          clientCert: null,
+          cognitoAuthenticationProvider: null,
+          cognitoAuthenticationType: null,
+          cognitoIdentityId: null,
+          cognitoIdentityPoolId: null,
+          principalOrgId: null,
           sourceIp: "",
-          user: "",
-          userAgent: "",
-          userArn: "",
+          user: null,
+          userAgent: null,
+          userArn: null,
         },
         path: "/webhook",
         protocol: "HTTP/1.1",
@@ -272,9 +213,7 @@ describe("Unit test for app handler", function () {
       resource: "",
       stageVariables: {},
     };
-
     const result: APIGatewayProxyResult = await handler(event);
-
     expect(result.statusCode).toEqual(200);
     const body = JSON.parse(result.body);
     expect(body.message).toEqual("認可URLを送信しました");

--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -5,11 +5,11 @@ import { Config } from "../lib/config";
 import { TokenRepository } from "../lib/token-repository";
 import { LineMessagingApiClient } from "../line-messaging-api-client";
 
-const config = Config.getInstance();
+const configInitialization = (Config.getInstance()).init();
 
 export const calendarEventsHandler =
   async (): Promise<APIGatewayProxyResult> => {
-    await config.init();
+    await configInitialization;
     const responseBuilder = new ApiResponseBuilder();
     console.info("Start calendar events handler");
     try {

--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -2,19 +2,17 @@ import { ApiResponseBuilder } from "../lib/api-response-builder";
 import type { APIGatewayProxyResult } from "aws-lambda";
 import { CalendarEventsUseCase } from "../usecases/calendar-events-usecase";
 import { Config } from "../lib/config";
-import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { TokenRepository } from "../lib/token-repository";
 import { LineMessagingApiClient } from "../line-messaging-api-client";
 
+const config = Config.getInstance();
+
 export const calendarEventsHandler =
   async (): Promise<APIGatewayProxyResult> => {
+    await config.init();
     const responseBuilder = new ApiResponseBuilder();
     console.info("Start calendar events handler");
     try {
-      const config = Config.getInstance();
-      const parameterFetcher = new AwsParameterFetcher();
-      await config.init(parameterFetcher);
-
       const tokenRepository = new TokenRepository();
       const lineMessagingApiClient = new LineMessagingApiClient();
       await new CalendarEventsUseCase(

--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -9,6 +9,8 @@ import { OAuthStateRepository } from "../lib/oauth-state-repository";
 import { TokenRepository } from "../lib/token-repository";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
 
+const configInitialization = (Config.getInstance()).init();
+
 /**
  * LINE Messaging APIのWebhookイベントを処理するLambda関数
  * @param event - API Gateway Lambda Proxy Input Format
@@ -22,7 +24,7 @@ export const handler = async (
     console.debug({ event });
 
     // Configの初期化（環境変数やパラメータストアから設定値を取得）
-    await Config.getInstance().init();
+    await configInitialization;
 
     // Signature validation
     const signature =

--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -5,7 +5,6 @@ import { LineMessagingApiClient } from "../line-messaging-api-client";
 import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
 import type { LineWebhookEvent } from "../types/line-webhook-event";
 import { Config } from "../lib/config";
-import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { OAuthStateRepository } from "../lib/oauth-state-repository";
 import { TokenRepository } from "../lib/token-repository";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
@@ -23,9 +22,7 @@ export const handler = async (
     console.debug({ event });
 
     // Configの初期化（環境変数やパラメータストアから設定値を取得）
-    const fetcher = new AwsParameterFetcher();
-    console.debug({ fetcher });
-    await Config.getInstance().init(fetcher);
+    await Config.getInstance().init();
 
     // Signature validation
     const signature =

--- a/src/handlers/oauth-callback-handler.ts
+++ b/src/handlers/oauth-callback-handler.ts
@@ -2,21 +2,19 @@ import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { OAuthCallbackUseCase } from "../usecases/oauth-callback-usecase";
 import { OAuthStateRepository } from "../lib/oauth-state-repository";
 import { Config } from "../lib/config";
-import { AwsParameterFetcher } from "../lib/aws-parameter-fetcher";
 import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
 import { TokenRepository } from "../lib/token-repository";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
 
+// 設定の初期化
+const config = Config.getInstance();
+
 export const oauthCallbackHandler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
+  await config.init();
   try {
     console.info("Start OAuth callback handler");
-
-    // 設定の初期化
-    const config = Config.getInstance();
-    const parameterFetcher = new AwsParameterFetcher();
-    await config.init(parameterFetcher);
 
     // クエリパラメータから認可コードとstateを取得
     const code = event.queryStringParameters?.code;

--- a/src/handlers/oauth-callback-handler.ts
+++ b/src/handlers/oauth-callback-handler.ts
@@ -7,12 +7,12 @@ import { TokenRepository } from "../lib/token-repository";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
 
 // 設定の初期化
-const config = Config.getInstance();
+const configInitialization = (Config.getInstance()).init();
 
 export const oauthCallbackHandler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
-  await config.init();
+  await configInitialization;
   try {
     console.info("Start OAuth callback handler");
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { ParameterFetcherMock } from "../../__tests__/mocks/parameter-fetcher-mock";
+import { ParameterFetcherMock } from "./parameter-fetcher-mock";
 import type { Schema$ParameterFetcher } from "../types/lib/parameter-fetcher";
 import { AwsParameterFetcher } from "./aws-parameter-fetcher";
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -54,6 +54,7 @@ export class Config {
     this.GOOGLE_REDIRECT_URI = google_redirect_uri;
     this.LINE_CHANNEL_ACCESS_TOKEN = line_channel_access_token;
     this.LINE_CHANNEL_SECRET = line_channel_secret;
+    this.logInitialization();
   }
 
   private async envOrParameter(name: string): Promise<string> {
@@ -64,5 +65,13 @@ export class Config {
     }
 
     return this.paramsFetcher.call(name);
+  }
+
+  /**
+   * 設定初期化時のログ出力（ParameterFetcherのクラス名付き）
+   */
+  private logInitialization() {
+    const fetcherClass = this.paramsFetcher.constructor?.name || typeof this.paramsFetcher;
+    console.info(`Configuration initialized. ParameterFetcher: ${fetcherClass}`);
   }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,6 @@
+import { ParameterFetcherMock } from "../../__tests__/mocks/parameter-fetcher-mock";
 import type { Schema$ParameterFetcher } from "../types/lib/parameter-fetcher";
+import { AwsParameterFetcher } from "./aws-parameter-fetcher";
 
 export class Config {
   private paramsFetcher!: Schema$ParameterFetcher;
@@ -23,8 +25,15 @@ export class Config {
    * 初期化処理
    * 値を取得する前に必ず呼び出すこと
    */
-  async init(paramsFetcher: Schema$ParameterFetcher) {
-    this.paramsFetcher = paramsFetcher;
+  async init(paramsFetcher?: Schema$ParameterFetcher) {
+    if (paramsFetcher) {
+      this.paramsFetcher = paramsFetcher;
+    } else {
+      this.paramsFetcher =
+        process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development"
+          ? new ParameterFetcherMock()
+          : new AwsParameterFetcher();
+    }
 
     const [
       google_client_id,

--- a/src/lib/parameter-fetcher-mock.ts
+++ b/src/lib/parameter-fetcher-mock.ts
@@ -1,4 +1,4 @@
-import type { Schema$ParameterFetcher } from "../../src/types/lib/parameter-fetcher";
+import type { Schema$ParameterFetcher } from "../types/lib/parameter-fetcher";
 
 export class ParameterFetcherMock implements Schema$ParameterFetcher {
   call = async (name: string): Promise<string> => {


### PR DESCRIPTION
resolve https://github.com/yuma-ito-bd/schedule-line-reminder/issues/30

パラメータ取得用の`ParameterFetcher`を環境によって切り替えます。

- ローカル環境、テスト環境：`ParameterFetcherMock`クラス
- 本番環境：`AwsParameterFetcher`クラス
  - パラメータストアから取得するためのクラス

また、`Config.init`の実行をハンドラ外で行うことにより、Lambda関数の起動時（コールドスタート時）のみパラメータを読み込むようにした。
これにより、関数の呼び出しごとにパラメータを取得しなくてよくなり、APIの呼び出し回数が減るなどパフォーマンスが改善する。
また、テストファイル内での不要なモック処理を削除した。