### PR TITLE
パラメータストアのLambda Layerのバージョンを最新にする。

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -29,7 +29,7 @@ Resources:
       Timeout: 100
       Layers:
         # AWS Systems Managerのパラメータストアから設定値を取得するためのLambda Layer
-        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12
+        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:18
       Policies:
         - AWSLambdaBasicExecutionRole
         # AWS Systems Managerのパラメータストアから設定値を取得するためのポリシー
@@ -81,7 +81,7 @@ Resources:
         ApplicationLogLevel: DEBUG
       Layers:
         # AWS Systems Managerのパラメータストアから設定値を取得するためのLambda Layer
-        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12
+        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:18
       Policies:
         - AWSLambdaBasicExecutionRole
         # AWS Systems Managerのパラメータストアから設定値を取得するためのポリシー
@@ -133,7 +133,7 @@ Resources:
         ApplicationLogLevel: DEBUG
       Layers:
         # AWS Systems Managerのパラメータストアから設定値を取得するためのLambda Layer
-        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12
+        - arn:aws:lambda:ap-northeast-1:133490724326:layer:AWS-Parameters-and-Secrets-Lambda-Extension:18
       Policies:
         - AWSLambdaBasicExecutionRole
         # AWS Systems Managerのパラメータストアから設定値を取得するためのポリシー


### PR DESCRIPTION
パラメータストアからパラメータが取得できないエラーが発生しているため、まずは最新に追従する