### PR TITLE
fix: aws-sdk-client-mockの使用方法を修正

### DIFF
--- a/__tests__/lib/oauth-state-repository.test.ts
+++ b/__tests__/lib/oauth-state-repository.test.ts
@@ -1,33 +1,18 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  GetItemCommand,
+  DeleteItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import type { PutItemCommandInput } from "@aws-sdk/client-dynamodb";
 import { OAuthStateRepository } from "../../src/lib/oauth-state-repository";
 import { Config } from "../../src/lib/config";
 import { ParameterFetcherMock } from "../../src/lib/parameter-fetcher-mock";
-
-// DynamoDBClientのモック
-type MockDynamoDBCommand = {
-  input: {
-    TableName: string;
-    Item?: {
-      state: { S: string };
-      userId: { S: string };
-      ttl: { N: string };
-    };
-    Key?: {
-      state: { S: string };
-    };
-  };
-};
-
-const mockDynamoClient = {
-  send: mock((command: MockDynamoDBCommand) => Promise.resolve({})),
-};
-
-// DynamoDBClientのコンストラクタをモック
-mock.module("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: mock(() => mockDynamoClient),
-}));
+import { mockClient } from "aws-sdk-client-mock";
 
 describe("OAuthStateRepository", () => {
+  let dynamoDBMock: ReturnType<typeof mockClient>;
   let repository: OAuthStateRepository;
 
   beforeEach(async () => {
@@ -35,9 +20,12 @@ describe("OAuthStateRepository", () => {
     const parameterFetcher = new ParameterFetcherMock();
     await Config.getInstance().init(parameterFetcher);
 
-    // リポジトリのインスタンス化
-    repository = new OAuthStateRepository();
-    mockDynamoClient.send.mockClear();
+    // 環境変数の設定
+    process.env.STACK_NAME = "test-stack";
+    // モックの初期化
+    dynamoDBMock = mockClient(DynamoDBClient);
+    // リポジトリの初期化
+    repository = new OAuthStateRepository(300, dynamoDBMock as any);
   });
 
   describe("saveState", () => {
@@ -45,23 +33,25 @@ describe("OAuthStateRepository", () => {
       // Given
       const state = "test-state";
       const userId = "test-user-id";
-      const mockResponse = {};
-      mockDynamoClient.send.mockResolvedValueOnce(mockResponse);
+
+      // モックの設定
+      dynamoDBMock.on(PutItemCommand).resolves({
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      });
 
       // When
       await repository.saveState(state, userId);
 
       // Then
-      expect(mockDynamoClient.send).toHaveBeenCalledTimes(1);
-      const calls = mockDynamoClient.send.mock.calls;
-      expect(calls.length).toBe(1);
-      const command = calls[0][0] as MockDynamoDBCommand;
-      expect(command.input.TableName).toBe(
-        `${process.env.STACK_NAME}-oauth-state`
-      );
-      expect(command.input.Item?.state.S).toBe(state);
-      expect(command.input.Item?.userId.S).toBe(userId);
-      expect(Number(command.input.Item?.ttl.N)).toBeGreaterThan(
+      expect(dynamoDBMock.calls()).toHaveLength(1);
+      const call = dynamoDBMock.calls()[0];
+      const input = call.args[0].input as PutItemCommandInput;
+      expect(input.TableName).toBe("test-stack-oauth-state");
+      expect(input.Item?.state.S).toBe(state);
+      expect(input.Item?.userId.S).toBe(userId);
+      expect(Number(input.Item?.ttl.N)).toBeGreaterThan(
         Math.floor(Date.now() / 1000)
       );
     });
@@ -71,7 +61,7 @@ describe("OAuthStateRepository", () => {
       const state = "test-state";
       const userId = "test-user-id";
       const error = new Error("ConditionalCheckFailedException");
-      mockDynamoClient.send.mockRejectedValueOnce(error);
+      dynamoDBMock.on(PutItemCommand).rejects(error);
 
       // When & Then
       expect(repository.saveState(state, userId)).rejects.toThrow(
@@ -85,14 +75,22 @@ describe("OAuthStateRepository", () => {
       // Given
       const state = "test-state";
       const userId = "test-user-id";
-      const mockResponse = {
+
+      // モックの設定
+      dynamoDBMock.on(GetItemCommand).resolves({
         Item: {
           state: { S: state },
           userId: { S: userId },
         },
-      };
-      mockDynamoClient.send.mockResolvedValueOnce(mockResponse);
-      mockDynamoClient.send.mockResolvedValueOnce({}); // deleteStateの呼び出し
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      });
+      dynamoDBMock.on(DeleteItemCommand).resolves({
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      });
 
       // When
       const result = await repository.validateState(state);
@@ -102,19 +100,23 @@ describe("OAuthStateRepository", () => {
         isValid: true,
         userId,
       });
-      expect(mockDynamoClient.send).toHaveBeenCalledTimes(2);
+      expect(dynamoDBMock.calls()).toHaveLength(2);
     });
 
     it("無効なstateパラメータの場合、falseを返すこと", async () => {
       // Given
       const state = "test-state";
-      const mockResponse = {
+
+      // モックの設定
+      dynamoDBMock.on(GetItemCommand).resolves({
         Item: {
           state: { S: "different-state" },
           userId: { S: "test-user-id" },
         },
-      };
-      mockDynamoClient.send.mockResolvedValueOnce(mockResponse);
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      });
 
       // When
       const result = await repository.validateState(state);
@@ -124,14 +126,20 @@ describe("OAuthStateRepository", () => {
         isValid: false,
         userId: "test-user-id",
       });
-      expect(mockDynamoClient.send).toHaveBeenCalledTimes(1);
+      expect(dynamoDBMock.calls()).toHaveLength(1);
     });
 
     it("stateパラメータが存在しない場合、falseを返すこと", async () => {
       // Given
       const state = "test-state";
-      const mockResponse = {};
-      mockDynamoClient.send.mockResolvedValueOnce(mockResponse);
+
+      // モックの設定
+      dynamoDBMock.on(GetItemCommand).resolves({
+        Item: undefined,
+        $metadata: {
+          httpStatusCode: 200,
+        },
+      });
 
       // When
       const result = await repository.validateState(state);
@@ -140,14 +148,16 @@ describe("OAuthStateRepository", () => {
       expect(result).toEqual({
         isValid: false,
       });
-      expect(mockDynamoClient.send).toHaveBeenCalledTimes(1);
+      expect(dynamoDBMock.calls()).toHaveLength(1);
     });
 
     it("DynamoDBのエラーの場合、falseを返すこと", async () => {
       // Given
       const state = "test-state";
       const error = new Error("DynamoDB error");
-      mockDynamoClient.send.mockRejectedValueOnce(error);
+
+      // モックの設定
+      dynamoDBMock.on(GetItemCommand).rejects(error);
 
       // When
       const result = await repository.validateState(state);
@@ -156,7 +166,7 @@ describe("OAuthStateRepository", () => {
       expect(result).toEqual({
         isValid: false,
       });
-      expect(mockDynamoClient.send).toHaveBeenCalledTimes(1);
+      expect(dynamoDBMock.calls()).toHaveLength(1);
     });
   });
 });

--- a/__tests__/lib/oauth-state-repository.test.ts
+++ b/__tests__/lib/oauth-state-repository.test.ts
@@ -25,7 +25,7 @@ describe("OAuthStateRepository", () => {
     // モックの初期化
     dynamoDBMock = mockClient(DynamoDBClient);
     // リポジトリの初期化
-    repository = new OAuthStateRepository(300, dynamoDBMock as any);
+    repository = new OAuthStateRepository(300, dynamoDBMock as unknown as DynamoDBClient);
   });
 
   describe("saveState", () => {

--- a/__tests__/lib/token-repository.test.ts
+++ b/__tests__/lib/token-repository.test.ts
@@ -26,7 +26,7 @@ describe("TokenRepository", () => {
     // モックの初期化
     dynamoDBMock = mockClient(DynamoDBClient);
     // リポジトリの初期化
-    repository = new TokenRepository(dynamoDBMock as any);
+    repository = new TokenRepository(dynamoDBMock as unknown as DynamoDBClient);
   });
 
   describe("saveToken", () => {

--- a/__tests__/lib/token-repository.test.ts
+++ b/__tests__/lib/token-repository.test.ts
@@ -17,16 +17,16 @@ import { TokenRepository } from "../../src/lib/token-repository";
 import { mockClient } from "aws-sdk-client-mock";
 
 describe("TokenRepository", () => {
-  const dynamoDBMock = mockClient(DynamoDBClient);
+  let dynamoDBMock: ReturnType<typeof mockClient>;
   let repository: TokenRepository;
 
   beforeEach(() => {
     // 環境変数の設定
     process.env.STACK_NAME = "test-stack";
-    // モックのリセット
-    dynamoDBMock.reset();
+    // モックの初期化
+    dynamoDBMock = mockClient(DynamoDBClient);
     // リポジトリの初期化
-    repository = new TokenRepository();
+    repository = new TokenRepository(dynamoDBMock as any);
   });
 
   describe("saveToken", () => {

--- a/src/lib/oauth-state-repository.ts
+++ b/src/lib/oauth-state-repository.ts
@@ -15,8 +15,8 @@ export class OAuthStateRepository implements Schema$OAuthStateRepository {
   private readonly tableName: string;
   private readonly ttlSeconds: number;
 
-  constructor(ttlSeconds: number = 300) {
-    this.dynamoClient = new DynamoDBClient({});
+  constructor(ttlSeconds: number = 300, dynamoClient?: DynamoDBClient) {
+    this.dynamoClient = dynamoClient || new DynamoDBClient({});
     this.tableName = `${process.env.STACK_NAME}-oauth-state`;
     this.ttlSeconds = ttlSeconds;
   }

--- a/src/lib/token-repository.ts
+++ b/src/lib/token-repository.ts
@@ -21,8 +21,8 @@ export class TokenRepository implements Schema$TokenRepository {
   private readonly dynamoClient: DynamoDBClient;
   private readonly tableName: string;
 
-  constructor() {
-    this.dynamoClient = new DynamoDBClient({});
+  constructor(dynamoClient?: DynamoDBClient) {
+    this.dynamoClient = dynamoClient || new DynamoDBClient({});
     this.tableName = `${process.env.STACK_NAME}-oauth-tokens`;
   }
 


### PR DESCRIPTION
## 概要
https://github.com/yuma-ito-bd/schedule-line-reminder/actions/runs/16538051300/job/46775488948?pr=84#step:5:372 にてテストが落ちてしまっていたので、修正した。

```
__tests__/lib/token-repository.test.ts:
  
  # Unhandled error between tests
  -------------------------------
  
  Error: 
        at mockClient (/home/runner/work/schedule-line-reminder/schedule-line-reminder/node_modules/aws-sdk-client-mock/dist/cjs/mockClient.js:17:18)
        at <anonymous> (/home/runner/work/schedule-line-reminder/schedule-line-reminder/__tests__/lib/token-repository.test.ts:20:24)
        at /home/runner/work/schedule-line-reminder/schedule-line-reminder/__tests__/lib/token-repository.test.ts:19:1
        at loadAndEvaluateModule (2:1)
  12 |  * @param sandbox Optional sinon sandbox to use
  13 |  * @return Stub allowing to configure Client's behavior
  14 |  */
  15 | const mockClient = (client, { sandbox } = {}) => {
  16 |     const instance = isClientInstance(client) ? client : client.prototype;
  17 |     const send = instance.send;
                        ^
  TypeError: undefined is not an object (evaluating 'instance.send')
        at mockClient (/home/runner/work/schedule-line-reminder/schedule-line-reminder/node_modules/aws-sdk-client-mock/dist/cjs/mockClient.js:17:18)
        at <anonymous> (/home/runner/work/schedule-line-reminder/schedule-line-reminder/__tests__/lib/token-repository.test.ts:20:24)
        at /home/runner/work/schedule-line-reminder/schedule-line-reminder/__tests__/lib/token-repository.test.ts:19:1
        at loadAndEvaluateModule (2:1)
  -------------------------------
```

変更点は以下。

- TokenRepositoryとOAuthStateRepositoryにDynamoDBClientの依存性注入を追加
- テストファイルでmockClientの正しい使用方法に修正
