### PR TITLE
Compare timestamp formats for table columns

### DIFF
--- a/src/lib/user-calendar-repository.ts
+++ b/src/lib/user-calendar-repository.ts
@@ -29,12 +29,13 @@ export class UserCalendarRepository implements Schema$UserCalendarRepository {
    */
   async addCalendar(calendar: CreateUserCalendar): Promise<void> {
     const now = new Date();
+    const nowMs = now.getTime();
     const command = new PutItemCommand({
       TableName: this.tableName,
       Item: marshall({
         ...calendar,
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
+        createdAt: nowMs,
+        updatedAt: nowMs,
       }),
     });
     await this.dynamoClient.send(command);


### PR DESCRIPTION
Change `UserCalendarsTable` `createdAt` and `updatedAt` to store numeric epoch milliseconds for DynamoDB efficiency.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755298331281249?thread_ts=1755298331.281249&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-d637bdd0-25e8-483b-8fee-b26ee06d2ea7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d637bdd0-25e8-483b-8fee-b26ee06d2ea7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

