### PR TITLE
Implement preparation phase for line bot extension

### DIFF
--- a/src/handlers/line-webhook-handler.ts
+++ b/src/handlers/line-webhook-handler.ts
@@ -8,6 +8,7 @@ import { Config } from "../lib/config";
 import { OAuthStateRepository } from "../lib/oauth-state-repository";
 import { TokenRepository } from "../lib/token-repository";
 import { ApiResponseBuilder } from "../lib/api-response-builder";
+import { UserCalendarRepository } from "../lib/user-calendar-repository";
 
 const configInitialization = (Config.getInstance()).init();
 
@@ -62,11 +63,13 @@ export const handler = async (
     const googleAuth = new GoogleAuthAdapter();
     const stateRepository = new OAuthStateRepository();
     const tokenRepository = new TokenRepository();
+    const userCalendarRepository = new UserCalendarRepository();
     const webhookUseCase = new LineWebhookUseCase(
       lineClient,
       googleAuth,
       stateRepository,
-      tokenRepository
+      tokenRepository,
+      userCalendarRepository
     );
 
     // Webhookイベントの処理

--- a/src/line-messaging-api-client.ts
+++ b/src/line-messaging-api-client.ts
@@ -41,4 +41,46 @@ export class LineMessagingApiClient implements Schema$LineMessagingApiClient {
     console.debug(response);
     return response.body;
   }
+
+  async replyTextWithQuickReply(
+    replyToken: string,
+    text: string,
+    items: messagingApi.QuickReplyItem[]
+  ) {
+    const message: messagingApi.TextMessage = {
+      type: "text",
+      text,
+      quickReply: {
+        items,
+      },
+    };
+    const request: messagingApi.ReplyMessageRequest = {
+      replyToken,
+      messages: [message],
+    };
+    console.debug(request);
+    const response = await this.client.replyMessageWithHttpInfo(request);
+    console.debug(response);
+    return response.body;
+  }
+
+  async replyTemplateMessage(
+    replyToken: string,
+    altText: string,
+    template: messagingApi.TemplateMessage["template"]
+  ) {
+    const message: messagingApi.TemplateMessage = {
+      type: "template",
+      altText,
+      template,
+    };
+    const request: messagingApi.ReplyMessageRequest = {
+      replyToken,
+      messages: [message],
+    };
+    console.debug(request);
+    const response = await this.client.replyMessageWithHttpInfo(request);
+    console.debug(response);
+    return response.body;
+  }
 }

--- a/src/types/line-bot.d.ts
+++ b/src/types/line-bot.d.ts
@@ -1,0 +1,24 @@
+export type AddCalendarSelectPostbackData = {
+  action: "ADD_CALENDAR_SELECT";
+  calendarId: string;
+  calendarName: string;
+};
+
+export type DeleteCalendarConfirmPostbackData = {
+  action: "DELETE_CALENDAR_CONFIRM";
+  calendarId: string;
+  calendarName: string;
+};
+
+export type CancelPostbackData = {
+  action: "CANCEL";
+};
+
+export type PostbackData =
+  | AddCalendarSelectPostbackData
+  | DeleteCalendarConfirmPostbackData
+  | CancelPostbackData;
+
+export declare function serializePostbackData(data: PostbackData): string;
+
+export declare function parsePostbackData(data: string): PostbackData;

--- a/src/types/line-messaging-api-adapter.d.ts
+++ b/src/types/line-messaging-api-adapter.d.ts
@@ -9,4 +9,14 @@ export type Schema$LineMessagingApiClient = {
     replyToken: string,
     texts: string[]
   ) => Promise<messagingApi.ReplyMessageResponse>;
+  replyTextWithQuickReply: (
+    replyToken: string,
+    text: string,
+    items: messagingApi.QuickReplyItem[]
+  ) => Promise<messagingApi.ReplyMessageResponse>;
+  replyTemplateMessage: (
+    replyToken: string,
+    altText: string,
+    template: messagingApi.TemplateMessage["template"]
+  ) => Promise<messagingApi.ReplyMessageResponse>;
 };

--- a/src/types/line-webhook-event.d.ts
+++ b/src/types/line-webhook-event.d.ts
@@ -46,5 +46,31 @@ type UnfollowEvent = {
   mode: "active";
 };
 
+/** Postbackイベントの型定義 */
+type PostbackEvent = {
+  /** イベントの種類 */
+  type: "postback";
+  /** リプライトークン。メッセージに返信する際に使用 */
+  replyToken: string;
+  /** イベントの送信元情報 */
+  source: {
+    /** 送信元の種類。ユーザーからのメッセージの場合は "user" */
+    type: "user";
+    /** 送信元のユーザーID */
+    userId: string;
+  };
+  /** Postbackの内容 */
+  postback: {
+    /** data にシリアライズされた文字列 */
+    data: string;
+    /** 日付選択などの追加パラメータ */
+    params?: Record<string, unknown>;
+  };
+  /** イベントの発生時刻（UNIX時間） */
+  timestamp: number;
+  /** チャネルの状態。通常は "active" */
+  mode: "active";
+};
+
 /** LINE Messaging APIから受け取るWebhookイベントの型定義 */
-export type LineWebhookEvent = MessageEvent | UnfollowEvent;
+export type LineWebhookEvent = MessageEvent | UnfollowEvent | PostbackEvent;

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -4,13 +4,15 @@ import type { WebhookUseCaseResult } from "../types/webhook-usecase-result";
 import type { LineWebhookEvent } from "../types/line-webhook-event";
 import type { Schema$OAuthStateRepository } from "../types/oauth-state-repository";
 import type { Schema$TokenRepository } from "../types/token-repository";
+import type { Schema$UserCalendarRepository } from "../types/user-calendar-repository";
 
 export class LineWebhookUseCase {
   constructor(
     private readonly lineClient: Schema$LineMessagingApiClient,
     private readonly googleAuth: Schema$GoogleAuth,
     private readonly stateRepository: Schema$OAuthStateRepository,
-    private readonly tokenRepository: Schema$TokenRepository
+    private readonly tokenRepository: Schema$TokenRepository,
+    private readonly userCalendarRepository: Schema$UserCalendarRepository
   ) {}
 
   async handleWebhookEvent(

--- a/tasks_03_line_bot_functionality_extension.md
+++ b/tasks_03_line_bot_functionality_extension.md
@@ -68,7 +68,7 @@
 
 ## 関連ファイル
 - `src/use-cases/line-webhook-use-case.ts` - Webhook処理ロジック
-- `src/adapters/line-messaging-api-adapter.ts` - LINE API アダプター
+- `src/line-messaging-api-client.ts` - LINE API クライアント
 - `src/lib/session-manager.ts` - セッション管理（新規作成）
 - `src/types/line-bot.d.ts` - 型定義
 


### PR DESCRIPTION
Implement the '0.準備' phase to extend LINE bot functionality by adding postback event handling, new reply methods, and integrating a user calendar repository.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755302749817559?thread_ts=1755302749.817559&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-c11638da-6e37-420b-a574-096af2759eae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c11638da-6e37-420b-a574-096af2759eae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

