### PR TITLE
Create dockerfile for cursor background agent

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,16 @@
+{
+  "name": "Cursor Background Agent Env",
+  "docker": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "install": [
+    "set -eux",
+    "if [ -f package.json ] || [ -f bun.lockb ]; then bun install; fi",
+    "git --version",
+    "bun --version",
+    "sam --version"
+  ],
+  "terminals": [],
+  "env": {}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with Bun preinstalled (Debian-based)
-FROM oven/bun:1
+FROM oven/bun:1.2-debian
 
 # Avoid interactive prompts during apt operations
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Base image with Bun preinstalled (Debian-based)
+FROM oven/bun:1
+
+# Avoid interactive prompts during apt operations
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system packages and pipx for SAM CLI
+# - git: version control
+# - python3, python3-venv, python3-pip: required for pipx/venv
+# - pipx: recommended installer for aws-sam-cli
+# - curl, unzip, ca-certificates: common tooling used by many build scripts
+# Clean apt cache to reduce image size
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		git \
+		python3 \
+		python3-venv \
+		python3-pip \
+		pipx \
+		curl \
+		unzip \
+		ca-certificates; \
+	rm -rf /var/lib/apt/lists/*
+
+# Configure pipx to install binaries into a global, conventional path
+ENV PIPX_HOME=/opt/pipx \
+	PIPX_BIN_DIR=/usr/local/bin
+
+# Install AWS SAM CLI via pipx
+RUN set -eux; \
+	pipx install aws-sam-cli; \
+	# Show versions to verify install succeeded during image build
+	bun --version; \
+	git --version; \
+	sam --version
+
+# Set default working directory for Cursor-managed workspaces
+WORKDIR /workspace
+
+# The agent's runtime dependency installation should happen via your install script
+# configured in .cursor/environment.json, not in this Dockerfile.
+# Do not COPY your source here; Cursor manages checkout of the correct commit.
+
+# Default shell
+CMD ["bash"]


### PR DESCRIPTION
Add Dockerfile to set up Cursor Background Agent environment with Bun, Git, and AWS SAM CLI.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755337343643379?thread_ts=1755337343.643379&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-5a2361e5-b4d4-4a5d-ba1e-8d0c91fd09cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a2361e5-b4d4-4a5d-ba1e-8d0c91fd09cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

