### PR TITLE
Refactor line webhook constants and utilities

### DIFF
--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -13,6 +13,8 @@ const QUICK_REPLY_CALENDAR_LIMIT = 12; // LINE API limit is 13; we use 12 to lea
 const ADD_CALENDAR_SELECT = "ADD_CALENDAR_SELECT" as const;
 const DELETE_CALENDAR_SELECT = "DELETE_CALENDAR_SELECT" as const;
 
+type PostbackAction = typeof ADD_CALENDAR_SELECT | typeof DELETE_CALENDAR_SELECT;
+
 const MessageTemplates = {
   tokenDeleteSuccess: "トークン情報を削除しました",
   tokenDeleteFailure: "トークン情報の削除に失敗しました",
@@ -40,7 +42,7 @@ type PostbackEventType = Extract<LineWebhookEvent, { type: "postback" }>;
 type MessageEventType = Extract<LineWebhookEvent, { type: "message" }>;
 
 type ParsedPostbackData = {
-  action: string;
+  action: PostbackAction;
   calendarId?: string;
   calendarName?: string;
 };


### PR DESCRIPTION
Consolidate message strings and move `truncateLabel` into `LineWebhookUseCase` to centralize related logic and improve maintainability.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755343683619649?thread_ts=1755343683.619649&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-b2bf94fb-7ce5-40c1-a87e-c6ae3e96f4ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2bf94fb-7ce5-40c1-a87e-c6ae3e96f4ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

