### PR TITLE
Fix template.yml for dynamodb GetItem access

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -98,15 +98,20 @@ Resources:
               Action:
                 - "kms:Decrypt"
                 - "ssm:GetParameter"
-                - "dynamodb:PutItem"
-                - "dynamodb:DeleteItem"
               Resource:
                 [
                   Fn::Sub: "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/ssm",
                   Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/schedule-line-reminder/*",
-                  !GetAtt OAuthStateTable.Arn,
-                  !GetAtt OAuthTokensTable.Arn,
                 ]
+            - Effect: Allow
+              Action:
+                - "dynamodb:PutItem"
+              Resource: !GetAtt OAuthStateTable.Arn
+            - Effect: Allow
+              Action:
+                - "dynamodb:GetItem"
+                - "dynamodb:DeleteItem"
+              Resource: !GetAtt OAuthTokensTable.Arn
         # UserCalendarsTableに対する権限
         - Version: "2012-10-17"
           Statement:


### PR DESCRIPTION
Grant `dynamodb:GetItem` to `WebhookFunction` on `OAuthTokensTable` and refine IAM policies to follow least privilege.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755354730021249?thread_ts=1755354730.021249&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-18cc9f76-c48e-4ece-ae18-1c7e97d1f4d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18cc9f76-c48e-4ece-ae18-1c7e97d1f4d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

