### PR TITLE
Refactor calendar event notifications

### DIFF
--- a/src/handlers/calendar-events-handler.ts
+++ b/src/handlers/calendar-events-handler.ts
@@ -4,6 +4,7 @@ import { CalendarEventsUseCase } from "../usecases/calendar-events-usecase";
 import { Config } from "../lib/config";
 import { TokenRepository } from "../lib/token-repository";
 import { LineMessagingApiClient } from "../line-messaging-api-client";
+import { UserCalendarRepository } from "../lib/user-calendar-repository";
 
 const configInitialization = (Config.getInstance()).init();
 
@@ -15,9 +16,11 @@ export const calendarEventsHandler =
     try {
       const tokenRepository = new TokenRepository();
       const lineMessagingApiClient = new LineMessagingApiClient();
+      const userCalendarRepository = new UserCalendarRepository();
       await new CalendarEventsUseCase(
         tokenRepository,
-        lineMessagingApiClient
+        lineMessagingApiClient,
+        userCalendarRepository
       ).execute();
       console.info("End calendar events handler");
 

--- a/src/usecases/calendar-events-usecase.ts
+++ b/src/usecases/calendar-events-usecase.ts
@@ -3,11 +3,13 @@ import { GoogleCalendarApiAdapter } from "../google-calendar-api-adapter";
 import { GoogleAuthAdapter } from "../lib/google-auth-adapter";
 import type { Schema$LineMessagingApiClient } from "../types/line-messaging-api-adapter";
 import type { Schema$TokenRepository, Token } from "../types/token-repository";
+import type { Schema$UserCalendarRepository } from "../types/user-calendar-repository";
 
 export class CalendarEventsUseCase {
   constructor(
     private readonly tokenRepository: Schema$TokenRepository,
-    private readonly lineMessagingApiClient: Schema$LineMessagingApiClient
+    private readonly lineMessagingApiClient: Schema$LineMessagingApiClient,
+    private readonly userCalendarRepository: Schema$UserCalendarRepository
   ) {}
 
   async execute(): Promise<void> {
@@ -41,10 +43,23 @@ export class CalendarEventsUseCase {
       });
 
       const googleCalendarApi = new GoogleCalendarApiAdapter(auth);
+
+      // ユーザーの購読カレンダー一覧を取得するプロバイダ
+      const targetCalendarIdsProvider = async () => {
+        try {
+          const calendars = await this.userCalendarRepository.getUserCalendars(token.userId);
+          const enabledIds = calendars.map((c) => c.calendarId).filter((id) => !!id);
+          return enabledIds.length > 0 ? enabledIds : ["primary"];
+        } catch (e) {
+          return ["primary"];
+        }
+      };
+
       await new CalendarEventsNotifier(
         googleCalendarApi,
         this.lineMessagingApiClient,
-        token.userId
+        token.userId,
+        targetCalendarIdsProvider
       ).call();
     } catch (error) {
       console.error(


### PR DESCRIPTION
Refactor calendar event notification to support multiple user-subscribed calendars.

This refactoring enhances the `CalendarEventsNotifier` to prioritize calendar IDs obtained from `UserCalendarRepository`, allowing notifications to be sent for all calendars a user has subscribed to, rather than just those listed directly by the Google Calendar API or the primary calendar.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755355973797829?thread_ts=1755355973.797829&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-b28c7195-baf5-4622-a8cb-b11a2cd3cd8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b28c7195-baf5-4622-a8cb-b11a2cd3cd8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

