### PR TITLE
Url encode uri parameter

### DIFF
--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -155,7 +155,7 @@ export class LineWebhookUseCase {
               action: {
                 type: "uri",
                 label: "Googleでログイン",
-                uri: url,
+                uri: encodeURI(url),
               },
             },
           ]


### PR DESCRIPTION
URL-encode the `uri` in `src/usecases/line-webhook-usecase.ts` to ensure the authorization URL functions safely when opened via LINE quick reply.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755390137005779?thread_ts=1755390137.005779&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-de9779e3-00ab-4982-a029-e63d58b686e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de9779e3-00ab-4982-a029-e63d58b686e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

