### PR TITLE
Unfollow event deletes user calendar and updates tests

### DIFF
--- a/__tests__/line-webhook-usecase.test.ts
+++ b/__tests__/line-webhook-usecase.test.ts
@@ -7,480 +7,480 @@ import type { LineWebhookEvent } from "../src/types/line-webhook-event";
 import { expect, test, describe, beforeEach, spyOn } from "bun:test";
 
 function createTextMessageEvent(text: string): LineWebhookEvent {
-	return {
-		type: "message",
-		message: {
-			type: "text",
-			text,
-		},
-		replyToken: "test-reply-token",
-		source: {
-			type: "user",
-			userId: "test-user-id",
-		},
-		timestamp: Date.now(),
-		mode: "active",
-	};
+  return {
+    type: "message",
+    message: {
+      type: "text",
+      text,
+    },
+    replyToken: "test-reply-token",
+    source: {
+      type: "user",
+      userId: "test-user-id",
+    },
+    timestamp: Date.now(),
+    mode: "active",
+  };
 }
 
 function createUnfollowEvent(): LineWebhookEvent {
-	return {
-		type: "unfollow",
-		source: {
-			type: "user",
-			userId: "test-user-id",
-		},
-		timestamp: Date.now(),
-		mode: "active",
-	};
+  return {
+    type: "unfollow",
+    source: {
+      type: "user",
+      userId: "test-user-id",
+    },
+    timestamp: Date.now(),
+    mode: "active",
+  };
 }
 
 function createPostbackEvent(data: string): LineWebhookEvent {
-	return {
-		type: "postback",
-		replyToken: "test-reply-token",
-		source: {
-			type: "user",
-			userId: "test-user-id",
-		},
-		postback: { data },
-		timestamp: Date.now(),
-		mode: "active",
-	} as any;
+  return {
+    type: "postback",
+    replyToken: "test-reply-token",
+    source: {
+      type: "user",
+      userId: "test-user-id",
+    },
+    postback: { data },
+    timestamp: Date.now(),
+    mode: "active",
+  } as any;
 }
 
 class DummyUserCalendarRepository {
-	async addCalendar() {}
-	async deleteCalendar() {}
-	async getUserCalendars() { return []; }
+  async addCalendar() {}
+  async deleteCalendar() {}
+  async getUserCalendars() { return []; }
 }
 
 describe("LineWebhookUseCase", () => {
-	let mockLineClient: LineMessagingApiClientMock;
-	let mockAuthUrlGenerator: MockGoogleAuth;
-	let mockStateRepository: MockOAuthStateRepository;
-	let mockTokenRepository: MockTokenRepository;
-	let useCase: LineWebhookUseCase;
+  let mockLineClient: LineMessagingApiClientMock;
+  let mockAuthUrlGenerator: MockGoogleAuth;
+  let mockStateRepository: MockOAuthStateRepository;
+  let mockTokenRepository: MockTokenRepository;
+  let useCase: LineWebhookUseCase;
 
-	beforeEach(() => {
-		mockLineClient = new LineMessagingApiClientMock();
-		mockAuthUrlGenerator = new MockGoogleAuth();
-		mockStateRepository = new MockOAuthStateRepository();
-		mockTokenRepository = new MockTokenRepository();
-		useCase = new LineWebhookUseCase(
-			mockLineClient,
-			mockAuthUrlGenerator,
-			mockStateRepository,
-			mockTokenRepository,
-			new DummyUserCalendarRepository() as any
-		);
-	});
+  beforeEach(() => {
+    mockLineClient = new LineMessagingApiClientMock();
+    mockAuthUrlGenerator = new MockGoogleAuth();
+    mockStateRepository = new MockOAuthStateRepository();
+    mockTokenRepository = new MockTokenRepository();
+    useCase = new LineWebhookUseCase(
+      mockLineClient,
+      mockAuthUrlGenerator,
+      mockStateRepository,
+      mockTokenRepository,
+      new DummyUserCalendarRepository() as any
+    );
+  });
 
-	describe("handleWebhookEvent", () => {
-		test("イベントがない場合はno eventメッセージを返す", async () => {
-			const result = await useCase.handleWebhookEvent(
-				null as unknown as LineWebhookEvent
-			);
-			expect(result).toEqual({ success: true, message: "no event" });
-		});
+  describe("handleWebhookEvent", () => {
+    test("イベントがない場合はno eventメッセージを返す", async () => {
+      const result = await useCase.handleWebhookEvent(
+        null as unknown as LineWebhookEvent
+      );
+      expect(result).toEqual({ success: true, message: "no event" });
+    });
 
-		test("カレンダー追加メッセージの場合、認可URLを送信する", async () => {
-			// Given
-			const event = createTextMessageEvent("カレンダー追加");
-			const guidance = "Googleカレンダーとの連携を開始します。以下のURLをクリックして認可を行ってください：";
+    test("カレンダー追加メッセージの場合、認可URLを送信する", async () => {
+      // Given
+      const event = createTextMessageEvent("カレンダー追加");
+      const guidance = "Googleカレンダーとの連携を開始します。以下のURLをクリックして認可を行ってください：";
 
-			const generateAuthUrlSpy = spyOn(mockAuthUrlGenerator, "generateAuthUrl");
-			const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
-			const saveStateSpy = spyOn(mockStateRepository, "saveState");
+      const generateAuthUrlSpy = spyOn(mockAuthUrlGenerator, "generateAuthUrl");
+      const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
+      const saveStateSpy = spyOn(mockStateRepository, "saveState");
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(generateAuthUrlSpy).toHaveBeenCalledTimes(1);
-			expect(saveStateSpy).toHaveBeenCalledWith(
-				expect.any(String),
-				"test-user-id"
-			);
-			expect(replyQuickSpy).toHaveBeenCalled();
-			const args = (replyQuickSpy.mock.calls[0] as any[]);
-			expect(args[0]).toBe("test-reply-token");
-			expect(args[1]).toBe(guidance);
-			const items = args[2];
-			expect(Array.isArray(items)).toBe(true);
-			expect(items.length).toBe(1);
-			expect(items[0].type).toBe("action");
-			expect(items[0].action.type).toBe("uri");
-			expect(items[0].action.label).toBe("Googleでログイン");
-			expect(items[0].action.uri).toBe("https://example.com/auth");
+      // Then
+      expect(generateAuthUrlSpy).toHaveBeenCalledTimes(1);
+      expect(saveStateSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        "test-user-id"
+      );
+      expect(replyQuickSpy).toHaveBeenCalled();
+      const args = (replyQuickSpy.mock.calls[0] as any[]);
+      expect(args[0]).toBe("test-reply-token");
+      expect(args[1]).toBe(guidance);
+      const items = args[2];
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBe(1);
+      expect(items[0].type).toBe("action");
+      expect(items[0].action.type).toBe("uri");
+      expect(items[0].action.label).toBe("Googleでログイン");
+      expect(items[0].action.uri).toBe("https://example.com/auth");
 
-			expect(result).toEqual({
-				success: true,
-				message: "認可URLを送信しました",
-			});
-		});
+      expect(result).toEqual({
+        success: true,
+        message: "認可URLを送信しました",
+      });
+    });
 
-		test("未対応のメッセージの場合は未対応メッセージを返す", async () => {
-			// Given
-			const event = createTextMessageEvent("その他のメッセージ");
-			const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
+    test("未対応のメッセージの場合は未対応メッセージを返す", async () => {
+      // Given
+      const event = createTextMessageEvent("その他のメッセージ");
+      const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(replyTextMessagesSpy).not.toHaveBeenCalled();
-			expect(result).toEqual({
-				success: true,
-				message: "未対応のメッセージです",
-			});
-		});
+      // Then
+      expect(replyTextMessagesSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: "未対応のメッセージです",
+      });
+    });
 
-		test("unfollowイベントの場合、トークン情報を削除しユーザーカレンダーも削除する", async () => {
-			// Given
-			const event = createUnfollowEvent();
-			const deleteTokenSpy = spyOn(mockTokenRepository, "deleteToken");
-			const getCalendarsSpy = spyOn(
-				DummyUserCalendarRepository.prototype as any,
-				"getUserCalendars"
-			).mockResolvedValue([
-				{ userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事", createdAt: new Date(), updatedAt: new Date() },
-				{ userId: "test-user-id", calendarId: "cal-2", calendarName: "プライベート", createdAt: new Date(), updatedAt: new Date() },
-			]);
-			const deleteCalendarSpy = spyOn(
-				DummyUserCalendarRepository.prototype as any,
-				"deleteCalendar"
-			).mockResolvedValue(undefined);
+    test("unfollowイベントの場合、トークン情報を削除しユーザーカレンダーも削除する", async () => {
+      // Given
+      const event = createUnfollowEvent();
+      const deleteTokenSpy = spyOn(mockTokenRepository, "deleteToken");
+      const getCalendarsSpy = spyOn(
+        DummyUserCalendarRepository.prototype as any,
+        "getUserCalendars"
+      ).mockResolvedValue([
+        { userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事", createdAt: new Date(), updatedAt: new Date() },
+        { userId: "test-user-id", calendarId: "cal-2", calendarName: "プライベート", createdAt: new Date(), updatedAt: new Date() },
+      ]);
+      const deleteCalendarSpy = spyOn(
+        DummyUserCalendarRepository.prototype as any,
+        "deleteCalendar"
+      ).mockResolvedValue(undefined);
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
-			expect(getCalendarsSpy).toHaveBeenCalledWith("test-user-id");
-			expect(deleteCalendarSpy).toHaveBeenCalledTimes(2);
-			expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
-			expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-2");
-			expect(result).toEqual({
-				success: true,
-				message: "トークン情報を削除しました",
-			});
-		});
+      // Then
+      expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
+      expect(getCalendarsSpy).toHaveBeenCalledWith("test-user-id");
+      expect(deleteCalendarSpy).toHaveBeenCalledTimes(2);
+      expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
+      expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-2");
+      expect(result).toEqual({
+        success: true,
+        message: "トークン情報を削除しました",
+      });
+    });
 
-		test("unfollowイベントでトークン削除に失敗した場合、エラーメッセージを返す", async () => {
-			// Given
-			const event = createUnfollowEvent();
-			const deleteTokenSpy = spyOn(
-				mockTokenRepository,
-				"deleteToken"
-			).mockRejectedValue(new Error("Failed to delete token"));
+    test("unfollowイベントでトークン削除に失敗した場合、エラーメッセージを返す", async () => {
+      // Given
+      const event = createUnfollowEvent();
+      const deleteTokenSpy = spyOn(
+        mockTokenRepository,
+        "deleteToken"
+      ).mockRejectedValue(new Error("Failed to delete token"));
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
-			expect(result).toEqual({
-				success: false,
-				message: "トークン情報の削除に失敗しました",
-			});
-		});
+      // Then
+      expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
+      expect(result).toEqual({
+        success: false,
+        message: "トークン情報の削除に失敗しました",
+      });
+    });
 
-		// New tests for "カレンダー一覧" feature
-		test("カレンダー一覧メッセージの場合、購読中カレンダーを整形して返信する", async () => {
-			// Given
-			const event = createTextMessageEvent("カレンダー一覧");
-			const mockUserCalendarRepository = {
-				async getUserCalendars(userId: string) {
-					expect(userId).toBe("test-user-id");
-					return [
-						{
-							userId: "test-user-id",
-							calendarId: "cal-1",
-							calendarName: "仕事",
-							createdAt: new Date(),
-							updatedAt: new Date(),
-						},
-						{
-							userId: "test-user-id",
-							calendarId: "cal-2",
-							calendarName: "プライベート",
-							createdAt: new Date(),
-							updatedAt: new Date(),
-						},
-					];
-				},
-			} as any;
-			const useCaseWithCalendars = new LineWebhookUseCase(
-				mockLineClient,
-				mockAuthUrlGenerator,
-				mockStateRepository,
-				mockTokenRepository,
-				mockUserCalendarRepository
-			);
-			const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
+    // New tests for "カレンダー一覧" feature
+    test("カレンダー一覧メッセージの場合、購読中カレンダーを整形して返信する", async () => {
+      // Given
+      const event = createTextMessageEvent("カレンダー一覧");
+      const mockUserCalendarRepository = {
+        async getUserCalendars(userId: string) {
+          expect(userId).toBe("test-user-id");
+          return [
+            {
+              userId: "test-user-id",
+              calendarId: "cal-1",
+              calendarName: "仕事",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              userId: "test-user-id",
+              calendarId: "cal-2",
+              calendarName: "プライベート",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ];
+        },
+      } as any;
+      const useCaseWithCalendars = new LineWebhookUseCase(
+        mockLineClient,
+        mockAuthUrlGenerator,
+        mockStateRepository,
+        mockTokenRepository,
+        mockUserCalendarRepository
+      );
+      const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result = await useCaseWithCalendars.handleWebhookEvent(event);
+      // When
+      const result = await useCaseWithCalendars.handleWebhookEvent(event);
 
-			// Then
-			expect(replyTextMessagesSpy).toHaveBeenCalledWith(
-				"test-reply-token",
-				[
-					[
-						"購読中のカレンダー:",
-						"- 仕事 (cal-1)",
-						"- プライベート (cal-2)",
-					].join("\n"),
-				]
-			);
-			expect(result).toEqual({
-				success: true,
-				message: "カレンダー一覧を返信しました",
-			});
-		});
+      // Then
+      expect(replyTextMessagesSpy).toHaveBeenCalledWith(
+        "test-reply-token",
+        [
+          [
+            "購読中のカレンダー:",
+            "- 仕事 (cal-1)",
+            "- プライベート (cal-2)",
+          ].join("\n"),
+        ]
+      );
+      expect(result).toEqual({
+        success: true,
+        message: "カレンダー一覧を返信しました",
+      });
+    });
 
-		test("カレンダー（短縮コマンド）の場合、購読カレンダーがない時はガイダンスを返信する", async () => {
-			// Given
-			const event = createTextMessageEvent("カレンダー");
-			const mockUserCalendarRepository = {
-				async getUserCalendars() {
-					return [];
-				},
-			} as any;
-			const useCaseNoCalendars = new LineWebhookUseCase(
-				mockLineClient,
-				mockAuthUrlGenerator,
-				mockStateRepository,
-				mockTokenRepository,
-				mockUserCalendarRepository
-			);
-			const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
+    test("カレンダー（短縮コマンド）の場合、購読カレンダーがない時はガイダンスを返信する", async () => {
+      // Given
+      const event = createTextMessageEvent("カレンダー");
+      const mockUserCalendarRepository = {
+        async getUserCalendars() {
+          return [];
+        },
+      } as any;
+      const useCaseNoCalendars = new LineWebhookUseCase(
+        mockLineClient,
+        mockAuthUrlGenerator,
+        mockStateRepository,
+        mockTokenRepository,
+        mockUserCalendarRepository
+      );
+      const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result = await useCaseNoCalendars.handleWebhookEvent(event);
+      // When
+      const result = await useCaseNoCalendars.handleWebhookEvent(event);
 
-			// Then
-			expect(replyTextMessagesSpy).toHaveBeenCalledWith(
-				"test-reply-token",
-				["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
-			);
-			expect(result).toEqual({
-				success: true,
-				message: "カレンダー一覧を返信しました",
-			});
-		});
+      // Then
+      expect(replyTextMessagesSpy).toHaveBeenCalledWith(
+        "test-reply-token",
+        ["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
+      );
+      expect(result).toEqual({
+        success: true,
+        message: "カレンダー一覧を返信しました",
+      });
+    });
 
-		// New tests for calendar add quick reply flow (with factory DI)
-		test("カレンダー追加: トークン登録済みならクイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
-			// Given
-			const event = createTextMessageEvent("カレンダー追加");
-			const longName = "これは非常に長いカレンダー名で20文字を超えます"; // > 20 chars
-			const mockUserCalendarRepository = new DummyUserCalendarRepository();
-			const useCaseWithToken = new LineWebhookUseCase(
-				mockLineClient,
-				mockAuthUrlGenerator,
-				mockStateRepository,
-				{
-					...mockTokenRepository,
-					async getToken() {
-						return {
-							userId: "test-user-id",
-							accessToken: "access",
-							refreshToken: "refresh",
-						};
-					},
-				} as any,
-				mockUserCalendarRepository as any,
-				() => ({
-					async fetchCalendarList() {
-						return [
-							{ id: "cal-1", summary: longName },
-							{ id: "cal-2", summary: "短い" },
-						] as any;
-					},
-					async fetchEvents() { return []; },
-				}) as any
-			);
-			// stub google auth setTokens (no-op)
-			spyOn(mockAuthUrlGenerator, "setTokens").mockReturnValue();
+    // New tests for calendar add quick reply flow (with factory DI)
+    test("カレンダー追加: トークン登録済みならクイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
+      // Given
+      const event = createTextMessageEvent("カレンダー追加");
+      const longName = "これは非常に長いカレンダー名で20文字を超えます"; // > 20 chars
+      const mockUserCalendarRepository = new DummyUserCalendarRepository();
+      const useCaseWithToken = new LineWebhookUseCase(
+        mockLineClient,
+        mockAuthUrlGenerator,
+        mockStateRepository,
+        {
+          ...mockTokenRepository,
+          async getToken() {
+            return {
+              userId: "test-user-id",
+              accessToken: "access",
+              refreshToken: "refresh",
+            };
+          },
+        } as any,
+        mockUserCalendarRepository as any,
+        () => ({
+          async fetchCalendarList() {
+            return [
+              { id: "cal-1", summary: longName },
+              { id: "cal-2", summary: "短い" },
+            ] as any;
+          },
+          async fetchEvents() { return []; },
+        }) as any
+      );
+      // stub google auth setTokens (no-op)
+      spyOn(mockAuthUrlGenerator, "setTokens").mockReturnValue();
 
-			// Spy on client to assert quick reply was used
-			const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
+      // Spy on client to assert quick reply was used
+      const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
 
-			// When
-			const result = await useCaseWithToken.handleWebhookEvent(event);
+      // When
+      const result = await useCaseWithToken.handleWebhookEvent(event);
 
-			// Then
-			expect(replyQuickSpy).toHaveBeenCalled();
-			const args = (replyQuickSpy.mock.calls[0] as any[]);
-			expect(args[0]).toBe("test-reply-token");
-			expect(args[1]).toBe("追加するカレンダーを選択してください");
-			const items = args[2];
-			expect(Array.isArray(items)).toBe(true);
-			expect(items.length).toBe(2);
-			// label truncated to <= 20
-			expect(items[0].action.label.length).toBeLessThanOrEqual(20);
-			expect(items[0].action.data).toContain("\"action\":\"ADD_CALENDAR_SELECT\"");
-			// rawLabel preserved in calendarName
-			expect(items[0].action.data).toContain(longName);
-			expect(result).toEqual({ success: true, message: "カレンダー追加クイックリプライを送信しました" });
-		});
+      // Then
+      expect(replyQuickSpy).toHaveBeenCalled();
+      const args = (replyQuickSpy.mock.calls[0] as any[]);
+      expect(args[0]).toBe("test-reply-token");
+      expect(args[1]).toBe("追加するカレンダーを選択してください");
+      const items = args[2];
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBe(2);
+      // label truncated to <= 20
+      expect(items[0].action.label.length).toBeLessThanOrEqual(20);
+      expect(items[0].action.data).toContain("\"action\":\"ADD_CALENDAR_SELECT\"");
+      // rawLabel preserved in calendarName
+      expect(items[0].action.data).toContain(longName);
+      expect(result).toEqual({ success: true, message: "カレンダー追加クイックリプライを送信しました" });
+    });
 
-		test("Postback: ADD_CALENDAR_SELECT でカレンダーを追加し、完了メッセージを返す", async () => {
-			// Given
-			const event = createPostbackEvent(
-				JSON.stringify({ action: "ADD_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
-			);
-			const addSpy: any = spyOn(DummyUserCalendarRepository.prototype, "addCalendar");
-			const replySpy = spyOn(mockLineClient, "replyTextMessages");
+    test("Postback: ADD_CALENDAR_SELECT でカレンダーを追加し、完了メッセージを返す", async () => {
+      // Given
+      const event = createPostbackEvent(
+        JSON.stringify({ action: "ADD_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
+      );
+      const addSpy: any = spyOn(DummyUserCalendarRepository.prototype, "addCalendar");
+      const replySpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(addSpy).toHaveBeenCalledWith({ userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事" });
-			expect(replySpy).toHaveBeenCalled();
-			expect(result).toEqual({ success: true, message: "カレンダー追加を完了しました" });
-		});
+      // Then
+      expect(addSpy).toHaveBeenCalledWith({ userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事" });
+      expect(replySpy).toHaveBeenCalled();
+      expect(result).toEqual({ success: true, message: "カレンダー追加を完了しました" });
+    });
 
-		test("Postback: JSON parse エラー時は失敗を返し、後続にフォールスルーしない", async () => {
-			// Given invalid JSON
-			const event = createPostbackEvent("{invalid-json}");
+    test("Postback: JSON parse エラー時は失敗を返し、後続にフォールスルーしない", async () => {
+      // Given invalid JSON
+      const event = createPostbackEvent("{invalid-json}");
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(result.success).toBe(false);
-			expect(result.message).toBe("ポストバック処理でエラーが発生しました");
-		});
+      // Then
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("ポストバック処理でエラーが発生しました");
+    });
 
-		// New tests for delete quick reply and postback deletion
-		test("カレンダー削除: 購読中がある場合、クイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
-			// Given
-			const event = createTextMessageEvent("カレンダー削除");
-			const longName = "とてもとても長い購読中のカレンダー名で二十文字超";
-			const mockUserCalendarRepository = {
-				async getUserCalendars(userId: string) {
-					expect(userId).toBe("test-user-id");
-					return [
-						{
-							userId: "test-user-id",
-							calendarId: "cal-1",
-							calendarName: longName,
-							createdAt: new Date(),
-							updatedAt: new Date(),
-						},
-						{
-							userId: "test-user-id",
-							calendarId: "cal-2",
-							calendarName: "短い",
-							createdAt: new Date(),
-							updatedAt: new Date(),
-						},
-					];
-				},
-			} as any;
-			const useCaseWithCalendars = new LineWebhookUseCase(
-				mockLineClient,
-				mockAuthUrlGenerator,
-				mockStateRepository,
-				mockTokenRepository,
-				mockUserCalendarRepository
-			);
-			const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
+    // New tests for delete quick reply and postback deletion
+    test("カレンダー削除: 購読中がある場合、クイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
+      // Given
+      const event = createTextMessageEvent("カレンダー削除");
+      const longName = "とてもとても長い購読中のカレンダー名で二十文字超";
+      const mockUserCalendarRepository = {
+        async getUserCalendars(userId: string) {
+          expect(userId).toBe("test-user-id");
+          return [
+            {
+              userId: "test-user-id",
+              calendarId: "cal-1",
+              calendarName: longName,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              userId: "test-user-id",
+              calendarId: "cal-2",
+              calendarName: "短い",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ];
+        },
+      } as any;
+      const useCaseWithCalendars = new LineWebhookUseCase(
+        mockLineClient,
+        mockAuthUrlGenerator,
+        mockStateRepository,
+        mockTokenRepository,
+        mockUserCalendarRepository
+      );
+      const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
 
-			// When
-			const result = await useCaseWithCalendars.handleWebhookEvent(event);
+      // When
+      const result = await useCaseWithCalendars.handleWebhookEvent(event);
 
-			// Then
-			expect(replyQuickSpy).toHaveBeenCalled();
-			const args = (replyQuickSpy.mock.calls[0] as any[]);
-			expect(args[0]).toBe("test-reply-token");
-			expect(args[1]).toBe("削除するカレンダーを選択してください");
-			const items = args[2];
-			expect(Array.isArray(items)).toBe(true);
-			expect(items.length).toBe(2);
-			// label truncated to <= 20
-			expect(items[0].action.label.length).toBeLessThanOrEqual(20);
-			expect(items[0].action.data).toContain("\"action\":\"DELETE_CALENDAR_SELECT\"");
-			expect(items[0].action.data).toContain("cal-1");
-			expect(items[0].action.data).toContain(longName);
-			expect(result).toEqual({ success: true, message: "カレンダー削除クイックリプライを送信しました" });
-		});
+      // Then
+      expect(replyQuickSpy).toHaveBeenCalled();
+      const args = (replyQuickSpy.mock.calls[0] as any[]);
+      expect(args[0]).toBe("test-reply-token");
+      expect(args[1]).toBe("削除するカレンダーを選択してください");
+      const items = args[2];
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBe(2);
+      // label truncated to <= 20
+      expect(items[0].action.label.length).toBeLessThanOrEqual(20);
+      expect(items[0].action.data).toContain("\"action\":\"DELETE_CALENDAR_SELECT\"");
+      expect(items[0].action.data).toContain("cal-1");
+      expect(items[0].action.data).toContain(longName);
+      expect(result).toEqual({ success: true, message: "カレンダー削除クイックリプライを送信しました" });
+    });
 
-		test("カレンダー削除: 購読が0件なら案内を返信する", async () => {
-			// Given
-			const event = createTextMessageEvent("カレンダー削除");
-			const mockUserCalendarRepository = {
-				async getUserCalendars() { return []; },
-			} as any;
-			const useCaseNoCalendars = new LineWebhookUseCase(
-				mockLineClient,
-				mockAuthUrlGenerator,
-				mockStateRepository,
-				mockTokenRepository,
-				mockUserCalendarRepository
-			);
-			const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
+    test("カレンダー削除: 購読が0件なら案内を返信する", async () => {
+      // Given
+      const event = createTextMessageEvent("カレンダー削除");
+      const mockUserCalendarRepository = {
+        async getUserCalendars() { return []; },
+      } as any;
+      const useCaseNoCalendars = new LineWebhookUseCase(
+        mockLineClient,
+        mockAuthUrlGenerator,
+        mockStateRepository,
+        mockTokenRepository,
+        mockUserCalendarRepository
+      );
+      const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result = await useCaseNoCalendars.handleWebhookEvent(event);
+      // When
+      const result = await useCaseNoCalendars.handleWebhookEvent(event);
 
-			// Then
-			expect(replyTextSpy).toHaveBeenCalledWith(
-				"test-reply-token",
-				["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
-			);
-			expect(result).toEqual({ success: true, message: "削除対象のカレンダーがありませんでした" });
-		});
+      // Then
+      expect(replyTextSpy).toHaveBeenCalledWith(
+        "test-reply-token",
+        ["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
+      );
+      expect(result).toEqual({ success: true, message: "削除対象のカレンダーがありませんでした" });
+    });
 
-		test("Postback: DELETE_CALENDAR_SELECT でカレンダーを削除し、完了メッセージを返す", async () => {
-			// Given
-			const event = createPostbackEvent(
-				JSON.stringify({ action: "DELETE_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
-			);
-			const deleteSpy: any = spyOn(DummyUserCalendarRepository.prototype, "deleteCalendar");
-			const replySpy = spyOn(mockLineClient, "replyTextMessages");
+    test("Postback: DELETE_CALENDAR_SELECT でカレンダーを削除し、完了メッセージを返す", async () => {
+      // Given
+      const event = createPostbackEvent(
+        JSON.stringify({ action: "DELETE_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
+      );
+      const deleteSpy: any = spyOn(DummyUserCalendarRepository.prototype, "deleteCalendar");
+      const replySpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(deleteSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
-			expect(replySpy).toHaveBeenCalled();
-			expect(result).toEqual({ success: true, message: "カレンダー削除を完了しました" });
-		});
+      // Then
+      expect(deleteSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
+      expect(replySpy).toHaveBeenCalled();
+      expect(result).toEqual({ success: true, message: "カレンダー削除を完了しました" });
+    });
 
-		// New tests for Help
-		test("ヘルプ/ help メッセージの場合、ヘルプを返信する", async () => {
-			// Given
-			const event1 = createTextMessageEvent("ヘルプ");
-			const event2 = createTextMessageEvent("help");
-			const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
+    // New tests for Help
+    test("ヘルプ/ help メッセージの場合、ヘルプを返信する", async () => {
+      // Given
+      const event1 = createTextMessageEvent("ヘルプ");
+      const event2 = createTextMessageEvent("help");
+      const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
 
-			// When
-			const result1 = await useCase.handleWebhookEvent(event1);
-			const result2 = await useCase.handleWebhookEvent(event2);
+      // When
+      const result1 = await useCase.handleWebhookEvent(event1);
+      const result2 = await useCase.handleWebhookEvent(event2);
 
-			// Then
-			expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.stringContaining("利用可能なコマンド:")]);
-			expect(result1).toEqual({ success: true, message: "ヘルプを返信しました" });
-			expect(result2).toEqual({ success: true, message: "ヘルプを返信しました" });
-		});
+      // Then
+      expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.stringContaining("利用可能なコマンド:")]);
+      expect(result1).toEqual({ success: true, message: "ヘルプを返信しました" });
+      expect(result2).toEqual({ success: true, message: "ヘルプを返信しました" });
+    });
 
-		test("ヘルプメッセージ送信に失敗した場合はエラーを返す", async () => {
-			// Given
-			const event = createTextMessageEvent("ヘルプ");
-			const replyTextSpy = spyOn(mockLineClient, "replyTextMessages").mockRejectedValue(new Error("send error"));
+    test("ヘルプメッセージ送信に失敗した場合はエラーを返す", async () => {
+      // Given
+      const event = createTextMessageEvent("ヘルプ");
+      const replyTextSpy = spyOn(mockLineClient, "replyTextMessages").mockRejectedValue(new Error("send error"));
 
-			// When
-			const result = await useCase.handleWebhookEvent(event);
+      // When
+      const result = await useCase.handleWebhookEvent(event);
 
-			// Then
-			expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.any(String)]);
-			expect(result).toEqual({ success: false, message: "ヘルプメッセージの送信に失敗しました" });
-		});
-	});
+      // Then
+      expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.any(String)]);
+      expect(result).toEqual({ success: false, message: "ヘルプメッセージの送信に失敗しました" });
+    });
+  });
 });

--- a/__tests__/line-webhook-usecase.test.ts
+++ b/__tests__/line-webhook-usecase.test.ts
@@ -53,6 +53,7 @@ class DummyUserCalendarRepository {
   async addCalendar() {}
   async deleteCalendar() {}
   async getUserCalendars() { return []; }
+  async deleteAll(userId: string, calendarIds: string[]) {}
 }
 
 describe("LineWebhookUseCase", () => {
@@ -147,9 +148,9 @@ describe("LineWebhookUseCase", () => {
         { userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事", createdAt: new Date(), updatedAt: new Date() },
         { userId: "test-user-id", calendarId: "cal-2", calendarName: "プライベート", createdAt: new Date(), updatedAt: new Date() },
       ]);
-      const deleteCalendarSpy = spyOn(
+      const deleteAllSpy = spyOn(
         DummyUserCalendarRepository.prototype as any,
-        "deleteCalendar"
+        "deleteAll"
       ).mockResolvedValue(undefined);
 
       // When
@@ -158,9 +159,7 @@ describe("LineWebhookUseCase", () => {
       // Then
       expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
       expect(getCalendarsSpy).toHaveBeenCalledWith("test-user-id");
-      expect(deleteCalendarSpy).toHaveBeenCalledTimes(2);
-      expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
-      expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-2");
+      expect(deleteAllSpy).toHaveBeenCalledWith("test-user-id", ["cal-1", "cal-2"]);
       expect(result).toEqual({
         success: true,
         message: "トークン情報を削除しました",

--- a/__tests__/line-webhook-usecase.test.ts
+++ b/__tests__/line-webhook-usecase.test.ts
@@ -7,465 +7,480 @@ import type { LineWebhookEvent } from "../src/types/line-webhook-event";
 import { expect, test, describe, beforeEach, spyOn } from "bun:test";
 
 function createTextMessageEvent(text: string): LineWebhookEvent {
-  return {
-    type: "message",
-    message: {
-      type: "text",
-      text,
-    },
-    replyToken: "test-reply-token",
-    source: {
-      type: "user",
-      userId: "test-user-id",
-    },
-    timestamp: Date.now(),
-    mode: "active",
-  };
+	return {
+		type: "message",
+		message: {
+			type: "text",
+			text,
+		},
+		replyToken: "test-reply-token",
+		source: {
+			type: "user",
+			userId: "test-user-id",
+		},
+		timestamp: Date.now(),
+		mode: "active",
+	};
 }
 
 function createUnfollowEvent(): LineWebhookEvent {
-  return {
-    type: "unfollow",
-    source: {
-      type: "user",
-      userId: "test-user-id",
-    },
-    timestamp: Date.now(),
-    mode: "active",
-  };
+	return {
+		type: "unfollow",
+		source: {
+			type: "user",
+			userId: "test-user-id",
+		},
+		timestamp: Date.now(),
+		mode: "active",
+	};
 }
 
 function createPostbackEvent(data: string): LineWebhookEvent {
-  return {
-    type: "postback",
-    replyToken: "test-reply-token",
-    source: {
-      type: "user",
-      userId: "test-user-id",
-    },
-    postback: { data },
-    timestamp: Date.now(),
-    mode: "active",
-  } as any;
+	return {
+		type: "postback",
+		replyToken: "test-reply-token",
+		source: {
+			type: "user",
+			userId: "test-user-id",
+		},
+		postback: { data },
+		timestamp: Date.now(),
+		mode: "active",
+	} as any;
 }
 
 class DummyUserCalendarRepository {
-  async addCalendar() {}
-  async deleteCalendar() {}
-  async getUserCalendars() { return []; }
+	async addCalendar() {}
+	async deleteCalendar() {}
+	async getUserCalendars() { return []; }
 }
 
 describe("LineWebhookUseCase", () => {
-  let mockLineClient: LineMessagingApiClientMock;
-  let mockAuthUrlGenerator: MockGoogleAuth;
-  let mockStateRepository: MockOAuthStateRepository;
-  let mockTokenRepository: MockTokenRepository;
-  let useCase: LineWebhookUseCase;
+	let mockLineClient: LineMessagingApiClientMock;
+	let mockAuthUrlGenerator: MockGoogleAuth;
+	let mockStateRepository: MockOAuthStateRepository;
+	let mockTokenRepository: MockTokenRepository;
+	let useCase: LineWebhookUseCase;
 
-  beforeEach(() => {
-    mockLineClient = new LineMessagingApiClientMock();
-    mockAuthUrlGenerator = new MockGoogleAuth();
-    mockStateRepository = new MockOAuthStateRepository();
-    mockTokenRepository = new MockTokenRepository();
-    useCase = new LineWebhookUseCase(
-      mockLineClient,
-      mockAuthUrlGenerator,
-      mockStateRepository,
-      mockTokenRepository,
-      new DummyUserCalendarRepository() as any
-    );
-  });
+	beforeEach(() => {
+		mockLineClient = new LineMessagingApiClientMock();
+		mockAuthUrlGenerator = new MockGoogleAuth();
+		mockStateRepository = new MockOAuthStateRepository();
+		mockTokenRepository = new MockTokenRepository();
+		useCase = new LineWebhookUseCase(
+			mockLineClient,
+			mockAuthUrlGenerator,
+			mockStateRepository,
+			mockTokenRepository,
+			new DummyUserCalendarRepository() as any
+		);
+	});
 
-  describe("handleWebhookEvent", () => {
-    test("イベントがない場合はno eventメッセージを返す", async () => {
-      const result = await useCase.handleWebhookEvent(
-        null as unknown as LineWebhookEvent
-      );
-      expect(result).toEqual({ success: true, message: "no event" });
-    });
+	describe("handleWebhookEvent", () => {
+		test("イベントがない場合はno eventメッセージを返す", async () => {
+			const result = await useCase.handleWebhookEvent(
+				null as unknown as LineWebhookEvent
+			);
+			expect(result).toEqual({ success: true, message: "no event" });
+		});
 
-    test("カレンダー追加メッセージの場合、認可URLを送信する", async () => {
-      // Given
-      const event = createTextMessageEvent("カレンダー追加");
-      const guidance = "Googleカレンダーとの連携を開始します。以下のURLをクリックして認可を行ってください：";
+		test("カレンダー追加メッセージの場合、認可URLを送信する", async () => {
+			// Given
+			const event = createTextMessageEvent("カレンダー追加");
+			const guidance = "Googleカレンダーとの連携を開始します。以下のURLをクリックして認可を行ってください：";
 
-      const generateAuthUrlSpy = spyOn(mockAuthUrlGenerator, "generateAuthUrl");
-      const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
-      const saveStateSpy = spyOn(mockStateRepository, "saveState");
+			const generateAuthUrlSpy = spyOn(mockAuthUrlGenerator, "generateAuthUrl");
+			const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
+			const saveStateSpy = spyOn(mockStateRepository, "saveState");
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(generateAuthUrlSpy).toHaveBeenCalledTimes(1);
-      expect(saveStateSpy).toHaveBeenCalledWith(
-        expect.any(String),
-        "test-user-id"
-      );
-      expect(replyQuickSpy).toHaveBeenCalled();
-      const args = (replyQuickSpy.mock.calls[0] as any[]);
-      expect(args[0]).toBe("test-reply-token");
-      expect(args[1]).toBe(guidance);
-      const items = args[2];
-      expect(Array.isArray(items)).toBe(true);
-      expect(items.length).toBe(1);
-      expect(items[0].type).toBe("action");
-      expect(items[0].action.type).toBe("uri");
-      expect(items[0].action.label).toBe("Googleでログイン");
-      expect(items[0].action.uri).toBe("https://example.com/auth");
+			// Then
+			expect(generateAuthUrlSpy).toHaveBeenCalledTimes(1);
+			expect(saveStateSpy).toHaveBeenCalledWith(
+				expect.any(String),
+				"test-user-id"
+			);
+			expect(replyQuickSpy).toHaveBeenCalled();
+			const args = (replyQuickSpy.mock.calls[0] as any[]);
+			expect(args[0]).toBe("test-reply-token");
+			expect(args[1]).toBe(guidance);
+			const items = args[2];
+			expect(Array.isArray(items)).toBe(true);
+			expect(items.length).toBe(1);
+			expect(items[0].type).toBe("action");
+			expect(items[0].action.type).toBe("uri");
+			expect(items[0].action.label).toBe("Googleでログイン");
+			expect(items[0].action.uri).toBe("https://example.com/auth");
 
-      expect(result).toEqual({
-        success: true,
-        message: "認可URLを送信しました",
-      });
-    });
+			expect(result).toEqual({
+				success: true,
+				message: "認可URLを送信しました",
+			});
+		});
 
-    test("未対応のメッセージの場合は未対応メッセージを返す", async () => {
-      // Given
-      const event = createTextMessageEvent("その他のメッセージ");
-      const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
+		test("未対応のメッセージの場合は未対応メッセージを返す", async () => {
+			// Given
+			const event = createTextMessageEvent("その他のメッセージ");
+			const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(replyTextMessagesSpy).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        success: true,
-        message: "未対応のメッセージです",
-      });
-    });
+			// Then
+			expect(replyTextMessagesSpy).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				success: true,
+				message: "未対応のメッセージです",
+			});
+		});
 
-    test("unfollowイベントの場合、トークン情報を削除する", async () => {
-      // Given
-      const event = createUnfollowEvent();
-      const deleteTokenSpy = spyOn(mockTokenRepository, "deleteToken");
+		test("unfollowイベントの場合、トークン情報を削除しユーザーカレンダーも削除する", async () => {
+			// Given
+			const event = createUnfollowEvent();
+			const deleteTokenSpy = spyOn(mockTokenRepository, "deleteToken");
+			const getCalendarsSpy = spyOn(
+				DummyUserCalendarRepository.prototype as any,
+				"getUserCalendars"
+			).mockResolvedValue([
+				{ userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事", createdAt: new Date(), updatedAt: new Date() },
+				{ userId: "test-user-id", calendarId: "cal-2", calendarName: "プライベート", createdAt: new Date(), updatedAt: new Date() },
+			]);
+			const deleteCalendarSpy = spyOn(
+				DummyUserCalendarRepository.prototype as any,
+				"deleteCalendar"
+			).mockResolvedValue(undefined);
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
-      expect(result).toEqual({
-        success: true,
-        message: "トークン情報を削除しました",
-      });
-    });
+			// Then
+			expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
+			expect(getCalendarsSpy).toHaveBeenCalledWith("test-user-id");
+			expect(deleteCalendarSpy).toHaveBeenCalledTimes(2);
+			expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
+			expect(deleteCalendarSpy).toHaveBeenCalledWith("test-user-id", "cal-2");
+			expect(result).toEqual({
+				success: true,
+				message: "トークン情報を削除しました",
+			});
+		});
 
-    test("unfollowイベントでトークン削除に失敗した場合、エラーメッセージを返す", async () => {
-      // Given
-      const event = createUnfollowEvent();
-      const deleteTokenSpy = spyOn(
-        mockTokenRepository,
-        "deleteToken"
-      ).mockRejectedValue(new Error("Failed to delete token"));
+		test("unfollowイベントでトークン削除に失敗した場合、エラーメッセージを返す", async () => {
+			// Given
+			const event = createUnfollowEvent();
+			const deleteTokenSpy = spyOn(
+				mockTokenRepository,
+				"deleteToken"
+			).mockRejectedValue(new Error("Failed to delete token"));
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
-      expect(result).toEqual({
-        success: false,
-        message: "トークン情報の削除に失敗しました",
-      });
-    });
+			// Then
+			expect(deleteTokenSpy).toHaveBeenCalledWith("test-user-id");
+			expect(result).toEqual({
+				success: false,
+				message: "トークン情報の削除に失敗しました",
+			});
+		});
 
-    // New tests for "カレンダー一覧" feature
-    test("カレンダー一覧メッセージの場合、購読中カレンダーを整形して返信する", async () => {
-      // Given
-      const event = createTextMessageEvent("カレンダー一覧");
-      const mockUserCalendarRepository = {
-        async getUserCalendars(userId: string) {
-          expect(userId).toBe("test-user-id");
-          return [
-            {
-              userId: "test-user-id",
-              calendarId: "cal-1",
-              calendarName: "仕事",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-            {
-              userId: "test-user-id",
-              calendarId: "cal-2",
-              calendarName: "プライベート",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-          ];
-        },
-      } as any;
-      const useCaseWithCalendars = new LineWebhookUseCase(
-        mockLineClient,
-        mockAuthUrlGenerator,
-        mockStateRepository,
-        mockTokenRepository,
-        mockUserCalendarRepository
-      );
-      const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
+		// New tests for "カレンダー一覧" feature
+		test("カレンダー一覧メッセージの場合、購読中カレンダーを整形して返信する", async () => {
+			// Given
+			const event = createTextMessageEvent("カレンダー一覧");
+			const mockUserCalendarRepository = {
+				async getUserCalendars(userId: string) {
+					expect(userId).toBe("test-user-id");
+					return [
+						{
+							userId: "test-user-id",
+							calendarId: "cal-1",
+							calendarName: "仕事",
+							createdAt: new Date(),
+							updatedAt: new Date(),
+						},
+						{
+							userId: "test-user-id",
+							calendarId: "cal-2",
+							calendarName: "プライベート",
+							createdAt: new Date(),
+							updatedAt: new Date(),
+						},
+					];
+				},
+			} as any;
+			const useCaseWithCalendars = new LineWebhookUseCase(
+				mockLineClient,
+				mockAuthUrlGenerator,
+				mockStateRepository,
+				mockTokenRepository,
+				mockUserCalendarRepository
+			);
+			const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result = await useCaseWithCalendars.handleWebhookEvent(event);
+			// When
+			const result = await useCaseWithCalendars.handleWebhookEvent(event);
 
-      // Then
-      expect(replyTextMessagesSpy).toHaveBeenCalledWith(
-        "test-reply-token",
-        [
-          [
-            "購読中のカレンダー:",
-            "- 仕事 (cal-1)",
-            "- プライベート (cal-2)",
-          ].join("\n"),
-        ]
-      );
-      expect(result).toEqual({
-        success: true,
-        message: "カレンダー一覧を返信しました",
-      });
-    });
+			// Then
+			expect(replyTextMessagesSpy).toHaveBeenCalledWith(
+				"test-reply-token",
+				[
+					[
+						"購読中のカレンダー:",
+						"- 仕事 (cal-1)",
+						"- プライベート (cal-2)",
+					].join("\n"),
+				]
+			);
+			expect(result).toEqual({
+				success: true,
+				message: "カレンダー一覧を返信しました",
+			});
+		});
 
-    test("カレンダー（短縮コマンド）の場合、購読カレンダーがない時はガイダンスを返信する", async () => {
-      // Given
-      const event = createTextMessageEvent("カレンダー");
-      const mockUserCalendarRepository = {
-        async getUserCalendars() {
-          return [];
-        },
-      } as any;
-      const useCaseNoCalendars = new LineWebhookUseCase(
-        mockLineClient,
-        mockAuthUrlGenerator,
-        mockStateRepository,
-        mockTokenRepository,
-        mockUserCalendarRepository
-      );
-      const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
+		test("カレンダー（短縮コマンド）の場合、購読カレンダーがない時はガイダンスを返信する", async () => {
+			// Given
+			const event = createTextMessageEvent("カレンダー");
+			const mockUserCalendarRepository = {
+				async getUserCalendars() {
+					return [];
+				},
+			} as any;
+			const useCaseNoCalendars = new LineWebhookUseCase(
+				mockLineClient,
+				mockAuthUrlGenerator,
+				mockStateRepository,
+				mockTokenRepository,
+				mockUserCalendarRepository
+			);
+			const replyTextMessagesSpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result = await useCaseNoCalendars.handleWebhookEvent(event);
+			// When
+			const result = await useCaseNoCalendars.handleWebhookEvent(event);
 
-      // Then
-      expect(replyTextMessagesSpy).toHaveBeenCalledWith(
-        "test-reply-token",
-        ["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
-      );
-      expect(result).toEqual({
-        success: true,
-        message: "カレンダー一覧を返信しました",
-      });
-    });
+			// Then
+			expect(replyTextMessagesSpy).toHaveBeenCalledWith(
+				"test-reply-token",
+				["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
+			);
+			expect(result).toEqual({
+				success: true,
+				message: "カレンダー一覧を返信しました",
+			});
+		});
 
-    // New tests for calendar add quick reply flow (with factory DI)
-    test("カレンダー追加: トークン登録済みならクイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
-      // Given
-      const event = createTextMessageEvent("カレンダー追加");
-      const longName = "これは非常に長いカレンダー名で20文字を超えます"; // > 20 chars
-      const mockUserCalendarRepository = new DummyUserCalendarRepository();
-      const useCaseWithToken = new LineWebhookUseCase(
-        mockLineClient,
-        mockAuthUrlGenerator,
-        mockStateRepository,
-        {
-          ...mockTokenRepository,
-          async getToken() {
-            return {
-              userId: "test-user-id",
-              accessToken: "access",
-              refreshToken: "refresh",
-            };
-          },
-        } as any,
-        mockUserCalendarRepository as any,
-        () => ({
-          async fetchCalendarList() {
-            return [
-              { id: "cal-1", summary: longName },
-              { id: "cal-2", summary: "短い" },
-            ] as any;
-          },
-          async fetchEvents() { return []; },
-        }) as any
-      );
-      // stub google auth setTokens (no-op)
-      spyOn(mockAuthUrlGenerator, "setTokens").mockReturnValue();
+		// New tests for calendar add quick reply flow (with factory DI)
+		test("カレンダー追加: トークン登録済みならクイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
+			// Given
+			const event = createTextMessageEvent("カレンダー追加");
+			const longName = "これは非常に長いカレンダー名で20文字を超えます"; // > 20 chars
+			const mockUserCalendarRepository = new DummyUserCalendarRepository();
+			const useCaseWithToken = new LineWebhookUseCase(
+				mockLineClient,
+				mockAuthUrlGenerator,
+				mockStateRepository,
+				{
+					...mockTokenRepository,
+					async getToken() {
+						return {
+							userId: "test-user-id",
+							accessToken: "access",
+							refreshToken: "refresh",
+						};
+					},
+				} as any,
+				mockUserCalendarRepository as any,
+				() => ({
+					async fetchCalendarList() {
+						return [
+							{ id: "cal-1", summary: longName },
+							{ id: "cal-2", summary: "短い" },
+						] as any;
+					},
+					async fetchEvents() { return []; },
+				}) as any
+			);
+			// stub google auth setTokens (no-op)
+			spyOn(mockAuthUrlGenerator, "setTokens").mockReturnValue();
 
-      // Spy on client to assert quick reply was used
-      const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
+			// Spy on client to assert quick reply was used
+			const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
 
-      // When
-      const result = await useCaseWithToken.handleWebhookEvent(event);
+			// When
+			const result = await useCaseWithToken.handleWebhookEvent(event);
 
-      // Then
-      expect(replyQuickSpy).toHaveBeenCalled();
-      const args = (replyQuickSpy.mock.calls[0] as any[]);
-      expect(args[0]).toBe("test-reply-token");
-      expect(args[1]).toBe("追加するカレンダーを選択してください");
-      const items = args[2];
-      expect(Array.isArray(items)).toBe(true);
-      expect(items.length).toBe(2);
-      // label truncated to <= 20
-      expect(items[0].action.label.length).toBeLessThanOrEqual(20);
-      expect(items[0].action.data).toContain("\"action\":\"ADD_CALENDAR_SELECT\"");
-      // rawLabel preserved in calendarName
-      expect(items[0].action.data).toContain(longName);
-      expect(result).toEqual({ success: true, message: "カレンダー追加クイックリプライを送信しました" });
-    });
+			// Then
+			expect(replyQuickSpy).toHaveBeenCalled();
+			const args = (replyQuickSpy.mock.calls[0] as any[]);
+			expect(args[0]).toBe("test-reply-token");
+			expect(args[1]).toBe("追加するカレンダーを選択してください");
+			const items = args[2];
+			expect(Array.isArray(items)).toBe(true);
+			expect(items.length).toBe(2);
+			// label truncated to <= 20
+			expect(items[0].action.label.length).toBeLessThanOrEqual(20);
+			expect(items[0].action.data).toContain("\"action\":\"ADD_CALENDAR_SELECT\"");
+			// rawLabel preserved in calendarName
+			expect(items[0].action.data).toContain(longName);
+			expect(result).toEqual({ success: true, message: "カレンダー追加クイックリプライを送信しました" });
+		});
 
-    test("Postback: ADD_CALENDAR_SELECT でカレンダーを追加し、完了メッセージを返す", async () => {
-      // Given
-      const event = createPostbackEvent(
-        JSON.stringify({ action: "ADD_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
-      );
-      const addSpy: any = spyOn(DummyUserCalendarRepository.prototype, "addCalendar");
-      const replySpy = spyOn(mockLineClient, "replyTextMessages");
+		test("Postback: ADD_CALENDAR_SELECT でカレンダーを追加し、完了メッセージを返す", async () => {
+			// Given
+			const event = createPostbackEvent(
+				JSON.stringify({ action: "ADD_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
+			);
+			const addSpy: any = spyOn(DummyUserCalendarRepository.prototype, "addCalendar");
+			const replySpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(addSpy).toHaveBeenCalledWith({ userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事" });
-      expect(replySpy).toHaveBeenCalled();
-      expect(result).toEqual({ success: true, message: "カレンダー追加を完了しました" });
-    });
+			// Then
+			expect(addSpy).toHaveBeenCalledWith({ userId: "test-user-id", calendarId: "cal-1", calendarName: "仕事" });
+			expect(replySpy).toHaveBeenCalled();
+			expect(result).toEqual({ success: true, message: "カレンダー追加を完了しました" });
+		});
 
-    test("Postback: JSON parse エラー時は失敗を返し、後続にフォールスルーしない", async () => {
-      // Given invalid JSON
-      const event = createPostbackEvent("{invalid-json}");
+		test("Postback: JSON parse エラー時は失敗を返し、後続にフォールスルーしない", async () => {
+			// Given invalid JSON
+			const event = createPostbackEvent("{invalid-json}");
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(result.success).toBe(false);
-      expect(result.message).toBe("ポストバック処理でエラーが発生しました");
-    });
+			// Then
+			expect(result.success).toBe(false);
+			expect(result.message).toBe("ポストバック処理でエラーが発生しました");
+		});
 
-    // New tests for delete quick reply and postback deletion
-    test("カレンダー削除: 購読中がある場合、クイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
-      // Given
-      const event = createTextMessageEvent("カレンダー削除");
-      const longName = "とてもとても長い購読中のカレンダー名で二十文字超";
-      const mockUserCalendarRepository = {
-        async getUserCalendars(userId: string) {
-          expect(userId).toBe("test-user-id");
-          return [
-            {
-              userId: "test-user-id",
-              calendarId: "cal-1",
-              calendarName: longName,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-            {
-              userId: "test-user-id",
-              calendarId: "cal-2",
-              calendarName: "短い",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            },
-          ];
-        },
-      } as any;
-      const useCaseWithCalendars = new LineWebhookUseCase(
-        mockLineClient,
-        mockAuthUrlGenerator,
-        mockStateRepository,
-        mockTokenRepository,
-        mockUserCalendarRepository
-      );
-      const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
+		// New tests for delete quick reply and postback deletion
+		test("カレンダー削除: 購読中がある場合、クイックリプライを送信し、ラベルは20文字に切り詰められる", async () => {
+			// Given
+			const event = createTextMessageEvent("カレンダー削除");
+			const longName = "とてもとても長い購読中のカレンダー名で二十文字超";
+			const mockUserCalendarRepository = {
+				async getUserCalendars(userId: string) {
+					expect(userId).toBe("test-user-id");
+					return [
+						{
+							userId: "test-user-id",
+							calendarId: "cal-1",
+							calendarName: longName,
+							createdAt: new Date(),
+							updatedAt: new Date(),
+						},
+						{
+							userId: "test-user-id",
+							calendarId: "cal-2",
+							calendarName: "短い",
+							createdAt: new Date(),
+							updatedAt: new Date(),
+						},
+					];
+				},
+			} as any;
+			const useCaseWithCalendars = new LineWebhookUseCase(
+				mockLineClient,
+				mockAuthUrlGenerator,
+				mockStateRepository,
+				mockTokenRepository,
+				mockUserCalendarRepository
+			);
+			const replyQuickSpy = spyOn(mockLineClient, "replyTextWithQuickReply");
 
-      // When
-      const result = await useCaseWithCalendars.handleWebhookEvent(event);
+			// When
+			const result = await useCaseWithCalendars.handleWebhookEvent(event);
 
-      // Then
-      expect(replyQuickSpy).toHaveBeenCalled();
-      const args = (replyQuickSpy.mock.calls[0] as any[]);
-      expect(args[0]).toBe("test-reply-token");
-      expect(args[1]).toBe("削除するカレンダーを選択してください");
-      const items = args[2];
-      expect(Array.isArray(items)).toBe(true);
-      expect(items.length).toBe(2);
-      // label truncated to <= 20
-      expect(items[0].action.label.length).toBeLessThanOrEqual(20);
-      expect(items[0].action.data).toContain("\"action\":\"DELETE_CALENDAR_SELECT\"");
-      expect(items[0].action.data).toContain("cal-1");
-      expect(items[0].action.data).toContain(longName);
-      expect(result).toEqual({ success: true, message: "カレンダー削除クイックリプライを送信しました" });
-    });
+			// Then
+			expect(replyQuickSpy).toHaveBeenCalled();
+			const args = (replyQuickSpy.mock.calls[0] as any[]);
+			expect(args[0]).toBe("test-reply-token");
+			expect(args[1]).toBe("削除するカレンダーを選択してください");
+			const items = args[2];
+			expect(Array.isArray(items)).toBe(true);
+			expect(items.length).toBe(2);
+			// label truncated to <= 20
+			expect(items[0].action.label.length).toBeLessThanOrEqual(20);
+			expect(items[0].action.data).toContain("\"action\":\"DELETE_CALENDAR_SELECT\"");
+			expect(items[0].action.data).toContain("cal-1");
+			expect(items[0].action.data).toContain(longName);
+			expect(result).toEqual({ success: true, message: "カレンダー削除クイックリプライを送信しました" });
+		});
 
-    test("カレンダー削除: 購読が0件なら案内を返信する", async () => {
-      // Given
-      const event = createTextMessageEvent("カレンダー削除");
-      const mockUserCalendarRepository = {
-        async getUserCalendars() { return []; },
-      } as any;
-      const useCaseNoCalendars = new LineWebhookUseCase(
-        mockLineClient,
-        mockAuthUrlGenerator,
-        mockStateRepository,
-        mockTokenRepository,
-        mockUserCalendarRepository
-      );
-      const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
+		test("カレンダー削除: 購読が0件なら案内を返信する", async () => {
+			// Given
+			const event = createTextMessageEvent("カレンダー削除");
+			const mockUserCalendarRepository = {
+				async getUserCalendars() { return []; },
+			} as any;
+			const useCaseNoCalendars = new LineWebhookUseCase(
+				mockLineClient,
+				mockAuthUrlGenerator,
+				mockStateRepository,
+				mockTokenRepository,
+				mockUserCalendarRepository
+			);
+			const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result = await useCaseNoCalendars.handleWebhookEvent(event);
+			// When
+			const result = await useCaseNoCalendars.handleWebhookEvent(event);
 
-      // Then
-      expect(replyTextSpy).toHaveBeenCalledWith(
-        "test-reply-token",
-        ["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
-      );
-      expect(result).toEqual({ success: true, message: "削除対象のカレンダーがありませんでした" });
-    });
+			// Then
+			expect(replyTextSpy).toHaveBeenCalledWith(
+				"test-reply-token",
+				["購読中のカレンダーはありません。『カレンダー追加』で登録できます。"]
+			);
+			expect(result).toEqual({ success: true, message: "削除対象のカレンダーがありませんでした" });
+		});
 
-    test("Postback: DELETE_CALENDAR_SELECT でカレンダーを削除し、完了メッセージを返す", async () => {
-      // Given
-      const event = createPostbackEvent(
-        JSON.stringify({ action: "DELETE_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
-      );
-      const deleteSpy: any = spyOn(DummyUserCalendarRepository.prototype, "deleteCalendar");
-      const replySpy = spyOn(mockLineClient, "replyTextMessages");
+		test("Postback: DELETE_CALENDAR_SELECT でカレンダーを削除し、完了メッセージを返す", async () => {
+			// Given
+			const event = createPostbackEvent(
+				JSON.stringify({ action: "DELETE_CALENDAR_SELECT", calendarId: "cal-1", calendarName: "仕事" })
+			);
+			const deleteSpy: any = spyOn(DummyUserCalendarRepository.prototype, "deleteCalendar");
+			const replySpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(deleteSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
-      expect(replySpy).toHaveBeenCalled();
-      expect(result).toEqual({ success: true, message: "カレンダー削除を完了しました" });
-    });
+			// Then
+			expect(deleteSpy).toHaveBeenCalledWith("test-user-id", "cal-1");
+			expect(replySpy).toHaveBeenCalled();
+			expect(result).toEqual({ success: true, message: "カレンダー削除を完了しました" });
+		});
 
-    // New tests for Help
-    test("ヘルプ/ help メッセージの場合、ヘルプを返信する", async () => {
-      // Given
-      const event1 = createTextMessageEvent("ヘルプ");
-      const event2 = createTextMessageEvent("help");
-      const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
+		// New tests for Help
+		test("ヘルプ/ help メッセージの場合、ヘルプを返信する", async () => {
+			// Given
+			const event1 = createTextMessageEvent("ヘルプ");
+			const event2 = createTextMessageEvent("help");
+			const replyTextSpy = spyOn(mockLineClient, "replyTextMessages");
 
-      // When
-      const result1 = await useCase.handleWebhookEvent(event1);
-      const result2 = await useCase.handleWebhookEvent(event2);
+			// When
+			const result1 = await useCase.handleWebhookEvent(event1);
+			const result2 = await useCase.handleWebhookEvent(event2);
 
-      // Then
-      expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.stringContaining("利用可能なコマンド:")]);
-      expect(result1).toEqual({ success: true, message: "ヘルプを返信しました" });
-      expect(result2).toEqual({ success: true, message: "ヘルプを返信しました" });
-    });
+			// Then
+			expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.stringContaining("利用可能なコマンド:")]);
+			expect(result1).toEqual({ success: true, message: "ヘルプを返信しました" });
+			expect(result2).toEqual({ success: true, message: "ヘルプを返信しました" });
+		});
 
-    test("ヘルプメッセージ送信に失敗した場合はエラーを返す", async () => {
-      // Given
-      const event = createTextMessageEvent("ヘルプ");
-      const replyTextSpy = spyOn(mockLineClient, "replyTextMessages").mockRejectedValue(new Error("send error"));
+		test("ヘルプメッセージ送信に失敗した場合はエラーを返す", async () => {
+			// Given
+			const event = createTextMessageEvent("ヘルプ");
+			const replyTextSpy = spyOn(mockLineClient, "replyTextMessages").mockRejectedValue(new Error("send error"));
 
-      // When
-      const result = await useCase.handleWebhookEvent(event);
+			// When
+			const result = await useCase.handleWebhookEvent(event);
 
-      // Then
-      expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.any(String)]);
-      expect(result).toEqual({ success: false, message: "ヘルプメッセージの送信に失敗しました" });
-    });
-  });
+			// Then
+			expect(replyTextSpy).toHaveBeenCalledWith("test-reply-token", [expect.any(String)]);
+			expect(result).toEqual({ success: false, message: "ヘルプメッセージの送信に失敗しました" });
+		});
+	});
 });

--- a/__tests__/line-webhook-usecase.test.ts
+++ b/__tests__/line-webhook-usecase.test.ts
@@ -105,17 +105,14 @@ describe("LineWebhookUseCase", () => {
 			expect(replyQuickSpy).toHaveBeenCalled();
 			const args = (replyQuickSpy.mock.calls[0] as any[]);
 			expect(args[0]).toBe("test-reply-token");
-			// message should include guidance and the URL with openExternalBrowser=1
-			expect(args[1]).toContain(guidance);
-			expect(args[1]).toContain("openExternalBrowser=1");
+			expect(args[1]).toBe(guidance);
 			const items = args[2];
 			expect(Array.isArray(items)).toBe(true);
 			expect(items.length).toBe(1);
 			expect(items[0].type).toBe("action");
 			expect(items[0].action.type).toBe("uri");
 			expect(items[0].action.label).toBe("Googleでログイン");
-			expect(items[0].action.uri).toContain("https://example.com/auth");
-			expect(items[0].action.uri).toContain("openExternalBrowser=1");
+			expect(items[0].action.uri).toBe("https://example.com/auth");
 
 			expect(result).toEqual({
 				success: true,

--- a/__tests__/line-webhook-usecase.test.ts
+++ b/__tests__/line-webhook-usecase.test.ts
@@ -105,14 +105,17 @@ describe("LineWebhookUseCase", () => {
 			expect(replyQuickSpy).toHaveBeenCalled();
 			const args = (replyQuickSpy.mock.calls[0] as any[]);
 			expect(args[0]).toBe("test-reply-token");
-			expect(args[1]).toBe(guidance);
+			// message should include guidance and the URL with openExternalBrowser=1
+			expect(args[1]).toContain(guidance);
+			expect(args[1]).toContain("openExternalBrowser=1");
 			const items = args[2];
 			expect(Array.isArray(items)).toBe(true);
 			expect(items.length).toBe(1);
 			expect(items[0].type).toBe("action");
 			expect(items[0].action.type).toBe("uri");
 			expect(items[0].action.label).toBe("Googleでログイン");
-			expect(items[0].action.uri).toBe("https://example.com/auth");
+			expect(items[0].action.uri).toContain("https://example.com/auth");
+			expect(items[0].action.uri).toContain("openExternalBrowser=1");
 
 			expect(result).toEqual({
 				success: true,

--- a/src/lib/user-calendar-repository.ts
+++ b/src/lib/user-calendar-repository.ts
@@ -58,6 +58,25 @@ export class UserCalendarRepository implements Schema$UserCalendarRepository {
   }
 
   /**
+   * 複数のカレンダーをまとめて削除する
+   * @param userId ユーザーID
+   * @param calendarIds 削除対象のカレンダーID一覧
+   */
+  async deleteAll(userId: string, calendarIds: string[]): Promise<void> {
+    if (!Array.isArray(calendarIds) || calendarIds.length === 0) return;
+    await Promise.all(
+      calendarIds.map((calendarId) =>
+        this.dynamoClient.send(
+          new DeleteItemCommand({
+            TableName: this.tableName,
+            Key: marshall({ userId, calendarId }),
+          })
+        )
+      )
+    );
+  }
+
+  /**
    * ユーザーの購読カレンダー一覧を取得する
    * @param userId ユーザーID
    * @returns ユーザーの購読カレンダー一覧

--- a/src/types/google-calendar-api-adapter.d.ts
+++ b/src/types/google-calendar-api-adapter.d.ts
@@ -1,15 +1,17 @@
 import { calendar_v3 } from "@googleapis/calendar";
 
-export type Schema$CalendarEvent = calendar_v3.Schema$Event;
-export type Schema$CalendarListEntry = calendar_v3.Schema$CalendarListEntry;
-
-export type Schema$GoogleCalendarApiAdapter = {
-	fetchEvents: (params: FetchEventsParams) => Promise<Schema$CalendarEvent[]>;
-	fetchCalendarList: () => Promise<Schema$CalendarListEntry[]>;
+export type CalendarListEntry = {
+  id?: string;
+  summary?: string;
 };
 
-export type FetchEventsParams = {
-	calendarId: string;
-	from: Date;
-	to: Date;
+export type CalendarEventEntry = {
+  id?: string;
+  summary?: string;
+  start?: { dateTime?: string; date?: string };
+};
+
+export type Schema$GoogleCalendarApiAdapter = {
+  fetchCalendarList(): Promise<CalendarListEntry[]>;
+  fetchEvents(calendarId: string): Promise<CalendarEventEntry[]>;
 };

--- a/src/types/google-calendar-api-adapter.d.ts
+++ b/src/types/google-calendar-api-adapter.d.ts
@@ -1,17 +1,15 @@
 import { calendar_v3 } from "@googleapis/calendar";
 
-export type CalendarListEntry = {
-  id?: string;
-  summary?: string;
-};
-
-export type CalendarEventEntry = {
-  id?: string;
-  summary?: string;
-  start?: { dateTime?: string; date?: string };
-};
+export type Schema$CalendarEvent = calendar_v3.Schema$Event;
+export type Schema$CalendarListEntry = calendar_v3.Schema$CalendarListEntry;
 
 export type Schema$GoogleCalendarApiAdapter = {
-  fetchCalendarList(): Promise<CalendarListEntry[]>;
-  fetchEvents(calendarId: string): Promise<CalendarEventEntry[]>;
+  fetchEvents: (params: FetchEventsParams) => Promise<Schema$CalendarEvent[]>;
+  fetchCalendarList: () => Promise<Schema$CalendarListEntry[]>;
+};
+
+export type FetchEventsParams = {
+  calendarId: string;
+  from: Date;
+  to: Date;
 };

--- a/src/types/user-calendar-repository.d.ts
+++ b/src/types/user-calendar-repository.d.ts
@@ -15,5 +15,6 @@ export type CreateUserCalendar = {
 export type Schema$UserCalendarRepository = {
   addCalendar(calendar: CreateUserCalendar): Promise<void>;
   deleteCalendar(userId: string, calendarId: string): Promise<void>;
+  deleteAll(userId: string, calendarIds: string[]): Promise<void>;
   getUserCalendars(userId: string): Promise<UserCalendar[]>;
 };

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -47,12 +47,9 @@ export class LineWebhookUseCase {
 
       // 2) Delete all user calendars
       const calendars = await this.userCalendarRepository.getUserCalendars(userId);
-      if (calendars.length > 0) {
-        await Promise.all(
-          calendars.map((c) =>
-            this.userCalendarRepository.deleteCalendar(userId, c.calendarId)
-          )
-        );
+      const calendarIds = calendars.map((c) => c.calendarId);
+      if (calendarIds.length > 0) {
+        await this.userCalendarRepository.deleteAll(userId, calendarIds);
       }
 
       return {

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -159,17 +159,16 @@ export class LineWebhookUseCase {
 			try {
 				const { url, state } = this.googleAuth.generateAuthUrl();
 				await this.stateRepository.saveState(state, userId);
-				const urlWithParam = url.includes("?") ? `${url}&openExternalBrowser=1` : `${url}?openExternalBrowser=1`;
 				await this.lineClient.replyTextWithQuickReply(
 					replyToken,
-					`${MessageTemplates.sendAuthGuidance}\n${urlWithParam}`,
+					MessageTemplates.sendAuthGuidance,
 					[
 						{
 							type: "action",
 							action: {
 								type: "uri",
 								label: "Googleでログイン",
-								uri: urlWithParam,
+								uri: url,
 							},
 						},
 					]

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -20,299 +20,299 @@ type MessageEventType = Extract<LineWebhookEvent, { type: "message" }>;
 
 
 function isTextMessageEvent(event: LineWebhookEvent): event is MessageEventType & { message: { type: "text"; text: string } } {
-	return (
-		event?.type === "message" &&
-		(event as MessageEventType).message?.type === "text"
-	);
+  return (
+    event?.type === "message" &&
+    (event as MessageEventType).message?.type === "text"
+  );
 }
 
 
 export class LineWebhookUseCase {
-	constructor(
-		private readonly lineClient: Schema$LineMessagingApiClient,
-		private readonly googleAuth: Schema$GoogleAuth,
-		private readonly stateRepository: Schema$OAuthStateRepository,
-		private readonly tokenRepository: Schema$TokenRepository,
-		private readonly userCalendarRepository: Schema$UserCalendarRepository,
-		private readonly calendarApiFactory: (
-			auth: Schema$GoogleAuth
-		) => Schema$GoogleCalendarApiAdapter = (auth) => new GoogleCalendarApiAdapter(auth)
-	) {}
+  constructor(
+    private readonly lineClient: Schema$LineMessagingApiClient,
+    private readonly googleAuth: Schema$GoogleAuth,
+    private readonly stateRepository: Schema$OAuthStateRepository,
+    private readonly tokenRepository: Schema$TokenRepository,
+    private readonly userCalendarRepository: Schema$UserCalendarRepository,
+    private readonly calendarApiFactory: (
+      auth: Schema$GoogleAuth
+    ) => Schema$GoogleCalendarApiAdapter = (auth) => new GoogleCalendarApiAdapter(auth)
+  ) {}
 
-	private async handleUnfollow(webhookEvent: UnfollowEventType): Promise<WebhookUseCaseResult> {
-		const userId = webhookEvent.source.userId;
-		try {
-			// 1) Delete OAuth token
-			await this.tokenRepository.deleteToken(userId);
+  private async handleUnfollow(webhookEvent: UnfollowEventType): Promise<WebhookUseCaseResult> {
+    const userId = webhookEvent.source.userId;
+    try {
+      // 1) Delete OAuth token
+      await this.tokenRepository.deleteToken(userId);
 
-			// 2) Delete all user calendars
-			const calendars = await this.userCalendarRepository.getUserCalendars(userId);
-			if (calendars.length > 0) {
-				await Promise.all(
-					calendars.map((c) =>
-						this.userCalendarRepository.deleteCalendar(userId, c.calendarId)
-					)
-				);
-			}
+      // 2) Delete all user calendars
+      const calendars = await this.userCalendarRepository.getUserCalendars(userId);
+      if (calendars.length > 0) {
+        await Promise.all(
+          calendars.map((c) =>
+            this.userCalendarRepository.deleteCalendar(userId, c.calendarId)
+          )
+        );
+      }
 
-			return {
-				success: true,
-				message: MessageTemplates.tokenDeleteSuccess,
-			};
-		} catch (error) {
-			console.error("Failed to cleanup on unfollow", {
-				userId,
-				action: "unfollow",
-				error,
-			});
-			return {
-				success: false,
-				message: MessageTemplates.tokenDeleteFailure,
-			};
-		}
-	}
+      return {
+        success: true,
+        message: MessageTemplates.tokenDeleteSuccess,
+      };
+    } catch (error) {
+      console.error("Failed to cleanup on unfollow", {
+        userId,
+        action: "unfollow",
+        error,
+      });
+      return {
+        success: false,
+        message: MessageTemplates.tokenDeleteFailure,
+      };
+    }
+  }
 
-	private async handlePostback(webhookEvent: PostbackEventType): Promise<WebhookUseCaseResult | null> {
-		try {
-			const userId = webhookEvent.source.userId;
-			const data = webhookEvent.postback.data;
-			const parsedUnknown = JSON.parse(data) as unknown;
+  private async handlePostback(webhookEvent: PostbackEventType): Promise<WebhookUseCaseResult | null> {
+    try {
+      const userId = webhookEvent.source.userId;
+      const data = webhookEvent.postback.data;
+      const parsedUnknown = JSON.parse(data) as unknown;
 
-			if (isAddCalendarPostback(parsedUnknown)) {
-				await this.userCalendarRepository.addCalendar({
-					userId,
-					calendarId: parsedUnknown.calendarId,
-					calendarName: parsedUnknown.calendarName,
-				});
-				await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
-					MessageTemplates.postbackAddReply(parsedUnknown.calendarName),
-				]);
-				return { success: true, message: MessageTemplates.postbackAddResult };
-			}
+      if (isAddCalendarPostback(parsedUnknown)) {
+        await this.userCalendarRepository.addCalendar({
+          userId,
+          calendarId: parsedUnknown.calendarId,
+          calendarName: parsedUnknown.calendarName,
+        });
+        await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
+          MessageTemplates.postbackAddReply(parsedUnknown.calendarName),
+        ]);
+        return { success: true, message: MessageTemplates.postbackAddResult };
+      }
 
-			if (isDeleteCalendarPostback(parsedUnknown)) {
-				await this.userCalendarRepository.deleteCalendar(userId, parsedUnknown.calendarId);
-				const name = parsedUnknown.calendarName || parsedUnknown.calendarId;
-				await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
-					MessageTemplates.postbackDeleteReply(name),
-				]);
-				return { success: true, message: MessageTemplates.postbackDeleteResult };
-			}
+      if (isDeleteCalendarPostback(parsedUnknown)) {
+        await this.userCalendarRepository.deleteCalendar(userId, parsedUnknown.calendarId);
+        const name = parsedUnknown.calendarName || parsedUnknown.calendarId;
+        await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
+          MessageTemplates.postbackDeleteReply(name),
+        ]);
+        return { success: true, message: MessageTemplates.postbackDeleteResult };
+      }
 
-			return null;
-		} catch (error) {
-			console.error("Failed to handle postback", {
-				userId: webhookEvent.source.userId,
-				action: "postback",
-				rawData: webhookEvent.postback.data,
-				error,
-			});
-			return { success: false, message: MessageTemplates.postbackError };
-		}
-	}
+      return null;
+    } catch (error) {
+      console.error("Failed to handle postback", {
+        userId: webhookEvent.source.userId,
+        action: "postback",
+        rawData: webhookEvent.postback.data,
+        error,
+      });
+      return { success: false, message: MessageTemplates.postbackError };
+    }
+  }
 
-	private async handleCalendarList(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-		try {
-			const calendars = await this.userCalendarRepository.getUserCalendars(userId);
-			if (calendars.length > 0) {
-				const lines = calendars.map((c) => `- ${c.calendarName} (${c.calendarId})`);
-				const message = [MessageTemplates.calendarListHeader, ...lines].join("\n");
-				await this.lineClient.replyTextMessages(replyToken, [message]);
-			} else {
-				await this.lineClient.replyTextMessages(replyToken, [
-					MessageTemplates.noSubscribedCalendars,
-				]);
-			}
-			return {
-				success: true,
-				message: "カレンダー一覧を返信しました",
-			};
-		} catch (error) {
-			console.error("Failed to reply calendar list", {
-				userId,
-				action: "calendar_list",
-				error,
-			});
-			return {
-				success: false,
-				message: MessageTemplates.calendarListFailure,
-			};
-		}
-	}
+  private async handleCalendarList(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+    try {
+      const calendars = await this.userCalendarRepository.getUserCalendars(userId);
+      if (calendars.length > 0) {
+        const lines = calendars.map((c) => `- ${c.calendarName} (${c.calendarId})`);
+        const message = [MessageTemplates.calendarListHeader, ...lines].join("\n");
+        await this.lineClient.replyTextMessages(replyToken, [message]);
+      } else {
+        await this.lineClient.replyTextMessages(replyToken, [
+          MessageTemplates.noSubscribedCalendars,
+        ]);
+      }
+      return {
+        success: true,
+        message: "カレンダー一覧を返信しました",
+      };
+    } catch (error) {
+      console.error("Failed to reply calendar list", {
+        userId,
+        action: "calendar_list",
+        error,
+      });
+      return {
+        success: false,
+        message: MessageTemplates.calendarListFailure,
+      };
+    }
+  }
 
-	private async handleCalendarAdd(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-		// Step 1: fetch token
-		let token;
-		try {
-			token = await this.tokenRepository.getToken(userId);
-		} catch (error) {
-			console.error("Failed to fetch token", {
-				userId,
-				action: "calendar_add_get_token",
-				error,
-			});
-			return { success: false, message: MessageTemplates.tokenFetchFailure };
-		}
+  private async handleCalendarAdd(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+    // Step 1: fetch token
+    let token;
+    try {
+      token = await this.tokenRepository.getToken(userId);
+    } catch (error) {
+      console.error("Failed to fetch token", {
+        userId,
+        action: "calendar_add_get_token",
+        error,
+      });
+      return { success: false, message: MessageTemplates.tokenFetchFailure };
+    }
 
-		// Step 2: if token is missing, send auth guidance and URL
-		if (!token) {
-			try {
-				const { url, state } = this.googleAuth.generateAuthUrl();
-				await this.stateRepository.saveState(state, userId);
-				await this.lineClient.replyTextWithQuickReply(
-					replyToken,
-					MessageTemplates.sendAuthGuidance,
-					[
-						{
-							type: "action",
-							action: {
-								type: "uri",
-								label: "Googleでログイン",
-								uri: url,
-							},
-						},
-					]
-				);
-				return {
-					success: true,
-					message: MessageTemplates.sendAuthUrlResult,
-				};
-			} catch (error) {
-				console.error("Failed to send auth URL", {
-					userId,
-					action: "calendar_add_auth",
-					error,
-				});
-				return { success: false, message: MessageTemplates.authUrlSendFailure };
-			}
-		}
+    // Step 2: if token is missing, send auth guidance and URL
+    if (!token) {
+      try {
+        const { url, state } = this.googleAuth.generateAuthUrl();
+        await this.stateRepository.saveState(state, userId);
+        await this.lineClient.replyTextWithQuickReply(
+          replyToken,
+          MessageTemplates.sendAuthGuidance,
+          [
+            {
+              type: "action",
+              action: {
+                type: "uri",
+                label: "Googleでログイン",
+                uri: url,
+              },
+            },
+          ]
+        );
+        return {
+          success: true,
+          message: MessageTemplates.sendAuthUrlResult,
+        };
+      } catch (error) {
+        console.error("Failed to send auth URL", {
+          userId,
+          action: "calendar_add_auth",
+          error,
+        });
+        return { success: false, message: MessageTemplates.authUrlSendFailure };
+      }
+    }
 
-		// Step 3: token exists → fetch calendar list and send quick reply
-		try {
-			this.googleAuth.setTokens(token);
-			const calendarApi = this.calendarApiFactory(this.googleAuth);
-			const list = await calendarApi.fetchCalendarList();
-			const calendarsForQuick = list
-				.filter((entry) => !!entry.id)
-				.map((entry) => ({
-					id: entry.id as string,
-					name: entry.summary || (entry.id as string) || "(no title)",
-				}));
-			const items = createCalendarQuickReplyItems(
-				calendarsForQuick,
-				ADD_CALENDAR_SELECT
-			);
-			await this.lineClient.replyTextWithQuickReply(
-				replyToken,
-				MessageTemplates.addQuickPrompt,
-				items
-			);
+    // Step 3: token exists → fetch calendar list and send quick reply
+    try {
+      this.googleAuth.setTokens(token);
+      const calendarApi = this.calendarApiFactory(this.googleAuth);
+      const list = await calendarApi.fetchCalendarList();
+      const calendarsForQuick = list
+        .filter((entry) => !!entry.id)
+        .map((entry) => ({
+          id: entry.id as string,
+          name: entry.summary || (entry.id as string) || "(no title)",
+        }));
+      const items = createCalendarQuickReplyItems(
+        calendarsForQuick,
+        ADD_CALENDAR_SELECT
+      );
+      await this.lineClient.replyTextWithQuickReply(
+        replyToken,
+        MessageTemplates.addQuickPrompt,
+        items
+      );
 
-			return { success: true, message: MessageTemplates.addQuickResult };
-		} catch (error) {
-			console.error("Failed to send add-calendar quick reply", {
-				userId,
-				action: "calendar_add_quick_reply",
-				error,
-			});
-			return { success: false, message: MessageTemplates.addQuickFailure };
-		}
-	}
+      return { success: true, message: MessageTemplates.addQuickResult };
+    } catch (error) {
+      console.error("Failed to send add-calendar quick reply", {
+        userId,
+        action: "calendar_add_quick_reply",
+        error,
+      });
+      return { success: false, message: MessageTemplates.addQuickFailure };
+    }
+  }
 
-	private async handleCalendarDelete(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-		try {
-			const calendars = await this.userCalendarRepository.getUserCalendars(userId);
-			if (calendars.length === 0) {
-				await this.lineClient.replyTextMessages(replyToken, [
-					MessageTemplates.noSubscribedCalendars,
-				]);
-				return { success: true, message: MessageTemplates.deleteNoTargetResult };
-			}
-			const calendarsForQuick = calendars.map((entry) => ({
-				id: entry.calendarId,
-				name: entry.calendarName || entry.calendarId,
-			}));
-			const items = createCalendarQuickReplyItems(
-				calendarsForQuick,
-				DELETE_CALENDAR_SELECT
-			);
-			await this.lineClient.replyTextWithQuickReply(
-				replyToken,
-				MessageTemplates.deleteQuickPrompt,
-				items
-			);
-			return { success: true, message: MessageTemplates.deleteQuickResult };
-		} catch (error) {
-			console.error("Failed to send delete-calendar quick reply", {
-				userId,
-				action: "calendar_delete_quick_reply",
-				error,
-			});
-			return { success: false, message: MessageTemplates.deleteQuickFailure };
-		}
-	}
+  private async handleCalendarDelete(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+    try {
+      const calendars = await this.userCalendarRepository.getUserCalendars(userId);
+      if (calendars.length === 0) {
+        await this.lineClient.replyTextMessages(replyToken, [
+          MessageTemplates.noSubscribedCalendars,
+        ]);
+        return { success: true, message: MessageTemplates.deleteNoTargetResult };
+      }
+      const calendarsForQuick = calendars.map((entry) => ({
+        id: entry.calendarId,
+        name: entry.calendarName || entry.calendarId,
+      }));
+      const items = createCalendarQuickReplyItems(
+        calendarsForQuick,
+        DELETE_CALENDAR_SELECT
+      );
+      await this.lineClient.replyTextWithQuickReply(
+        replyToken,
+        MessageTemplates.deleteQuickPrompt,
+        items
+      );
+      return { success: true, message: MessageTemplates.deleteQuickResult };
+    } catch (error) {
+      console.error("Failed to send delete-calendar quick reply", {
+        userId,
+        action: "calendar_delete_quick_reply",
+        error,
+      });
+      return { success: false, message: MessageTemplates.deleteQuickFailure };
+    }
+  }
 
-	private async handleHelp(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-		try {
-			await this.lineClient.replyTextMessages(replyToken, [MessageTemplates.helpText]);
-			return { success: true, message: MessageTemplates.helpResult };
-		} catch (error) {
-			console.error("Failed to send help message", {
-				userId,
-				action: "help",
-				error,
-			});
-			return { success: false, message: MessageTemplates.helpSendFailure };
-		}
-	}
+  private async handleHelp(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+    try {
+      await this.lineClient.replyTextMessages(replyToken, [MessageTemplates.helpText]);
+      return { success: true, message: MessageTemplates.helpResult };
+    } catch (error) {
+      console.error("Failed to send help message", {
+        userId,
+        action: "help",
+        error,
+      });
+      return { success: false, message: MessageTemplates.helpSendFailure };
+    }
+  }
 
-	private async handleMessage(webhookEvent: MessageEventType): Promise<WebhookUseCaseResult | null> {
-		if (webhookEvent.message.type !== "text") return null;
-		const text = webhookEvent.message.text;
+  private async handleMessage(webhookEvent: MessageEventType): Promise<WebhookUseCaseResult | null> {
+    if (webhookEvent.message.type !== "text") return null;
+    const text = webhookEvent.message.text;
 
-		if (/^(?:カレンダー一覧|カレンダー)$/.test(text)) {
-			return this.handleCalendarList(webhookEvent.source.userId, webhookEvent.replyToken);
-		}
-		if (text === "カレンダー追加") {
-			return this.handleCalendarAdd(webhookEvent.source.userId, webhookEvent.replyToken);
-		}
-		if (text === "カレンダー削除") {
-			return this.handleCalendarDelete(webhookEvent.source.userId, webhookEvent.replyToken);
-		}
-		if (/^(?:ヘルプ|help)$/i.test(text)) {
-			return this.handleHelp(webhookEvent.source.userId, webhookEvent.replyToken);
-		}
+    if (/^(?:カレンダー一覧|カレンダー)$/.test(text)) {
+      return this.handleCalendarList(webhookEvent.source.userId, webhookEvent.replyToken);
+    }
+    if (text === "カレンダー追加") {
+      return this.handleCalendarAdd(webhookEvent.source.userId, webhookEvent.replyToken);
+    }
+    if (text === "カレンダー削除") {
+      return this.handleCalendarDelete(webhookEvent.source.userId, webhookEvent.replyToken);
+    }
+    if (/^(?:ヘルプ|help)$/i.test(text)) {
+      return this.handleHelp(webhookEvent.source.userId, webhookEvent.replyToken);
+    }
 
-		return null;
-	}
+    return null;
+  }
 
-	async handleWebhookEvent(
-		webhookEvent: LineWebhookEvent
-	): Promise<WebhookUseCaseResult> {
-		if (!webhookEvent) {
-			return {
-				success: true,
-				message: MessageTemplates.noEvent,
-			};
-		}
+  async handleWebhookEvent(
+    webhookEvent: LineWebhookEvent
+  ): Promise<WebhookUseCaseResult> {
+    if (!webhookEvent) {
+      return {
+        success: true,
+        message: MessageTemplates.noEvent,
+      };
+    }
 
-		if (webhookEvent.type === "unfollow") {
-			return this.handleUnfollow(webhookEvent);
-		}
+    if (webhookEvent.type === "unfollow") {
+      return this.handleUnfollow(webhookEvent);
+    }
 
-		if (webhookEvent.type === "postback") {
-			const postbackResult = await this.handlePostback(webhookEvent);
-			if (postbackResult) return postbackResult;
-		}
+    if (webhookEvent.type === "postback") {
+      const postbackResult = await this.handlePostback(webhookEvent);
+      if (postbackResult) return postbackResult;
+    }
 
-		if (isTextMessageEvent(webhookEvent)) {
-			const messageResult = await this.handleMessage(webhookEvent);
-			if (messageResult) return messageResult;
-		}
+    if (isTextMessageEvent(webhookEvent)) {
+      const messageResult = await this.handleMessage(webhookEvent);
+      if (messageResult) return messageResult;
+    }
 
-		return {
-			success: true,
-			message: MessageTemplates.unsupportedMessage,
-		};
-	}
+    return {
+      success: true,
+      message: MessageTemplates.unsupportedMessage,
+    };
+  }
 }

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -48,9 +48,7 @@ export class LineWebhookUseCase {
       // 2) Delete all user calendars
       const calendars = await this.userCalendarRepository.getUserCalendars(userId);
       const calendarIds = calendars.map((c) => c.calendarId);
-      if (calendarIds.length > 0) {
-        await this.userCalendarRepository.deleteAll(userId, calendarIds);
-      }
+      await this.userCalendarRepository.deleteAll(userId, calendarIds);
 
       return {
         success: true,

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -159,16 +159,17 @@ export class LineWebhookUseCase {
 			try {
 				const { url, state } = this.googleAuth.generateAuthUrl();
 				await this.stateRepository.saveState(state, userId);
+				const urlWithParam = url.includes("?") ? `${url}&openExternalBrowser=1` : `${url}?openExternalBrowser=1`;
 				await this.lineClient.replyTextWithQuickReply(
 					replyToken,
-					MessageTemplates.sendAuthGuidance,
+					`${MessageTemplates.sendAuthGuidance}\n${urlWithParam}`,
 					[
 						{
 							type: "action",
 							action: {
 								type: "uri",
 								label: "Googleでログイン",
-								uri: url,
+								uri: urlWithParam,
 							},
 						},
 					]

--- a/src/usecases/line-webhook-usecase.ts
+++ b/src/usecases/line-webhook-usecase.ts
@@ -20,286 +20,299 @@ type MessageEventType = Extract<LineWebhookEvent, { type: "message" }>;
 
 
 function isTextMessageEvent(event: LineWebhookEvent): event is MessageEventType & { message: { type: "text"; text: string } } {
-  return (
-    event?.type === "message" &&
-    (event as MessageEventType).message?.type === "text"
-  );
+	return (
+		event?.type === "message" &&
+		(event as MessageEventType).message?.type === "text"
+	);
 }
 
 
 export class LineWebhookUseCase {
-  constructor(
-    private readonly lineClient: Schema$LineMessagingApiClient,
-    private readonly googleAuth: Schema$GoogleAuth,
-    private readonly stateRepository: Schema$OAuthStateRepository,
-    private readonly tokenRepository: Schema$TokenRepository,
-    private readonly userCalendarRepository: Schema$UserCalendarRepository,
-    private readonly calendarApiFactory: (
-      auth: Schema$GoogleAuth
-    ) => Schema$GoogleCalendarApiAdapter = (auth) => new GoogleCalendarApiAdapter(auth)
-  ) {}
+	constructor(
+		private readonly lineClient: Schema$LineMessagingApiClient,
+		private readonly googleAuth: Schema$GoogleAuth,
+		private readonly stateRepository: Schema$OAuthStateRepository,
+		private readonly tokenRepository: Schema$TokenRepository,
+		private readonly userCalendarRepository: Schema$UserCalendarRepository,
+		private readonly calendarApiFactory: (
+			auth: Schema$GoogleAuth
+		) => Schema$GoogleCalendarApiAdapter = (auth) => new GoogleCalendarApiAdapter(auth)
+	) {}
 
-  private async handleUnfollow(webhookEvent: UnfollowEventType): Promise<WebhookUseCaseResult> {
-    try {
-      await this.tokenRepository.deleteToken(webhookEvent.source.userId);
-      return {
-        success: true,
-        message: MessageTemplates.tokenDeleteSuccess,
-      };
-    } catch (error) {
-      console.error("Failed to delete token", {
-        userId: webhookEvent.source.userId,
-        action: "unfollow",
-        error,
-      });
-      return {
-        success: false,
-        message: MessageTemplates.tokenDeleteFailure,
-      };
-    }
-  }
+	private async handleUnfollow(webhookEvent: UnfollowEventType): Promise<WebhookUseCaseResult> {
+		const userId = webhookEvent.source.userId;
+		try {
+			// 1) Delete OAuth token
+			await this.tokenRepository.deleteToken(userId);
 
-  private async handlePostback(webhookEvent: PostbackEventType): Promise<WebhookUseCaseResult | null> {
-    try {
-      const userId = webhookEvent.source.userId;
-      const data = webhookEvent.postback.data;
-      const parsedUnknown = JSON.parse(data) as unknown;
+			// 2) Delete all user calendars
+			const calendars = await this.userCalendarRepository.getUserCalendars(userId);
+			if (calendars.length > 0) {
+				await Promise.all(
+					calendars.map((c) =>
+						this.userCalendarRepository.deleteCalendar(userId, c.calendarId)
+					)
+				);
+			}
 
-      if (isAddCalendarPostback(parsedUnknown)) {
-        await this.userCalendarRepository.addCalendar({
-          userId,
-          calendarId: parsedUnknown.calendarId,
-          calendarName: parsedUnknown.calendarName,
-        });
-        await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
-          MessageTemplates.postbackAddReply(parsedUnknown.calendarName),
-        ]);
-        return { success: true, message: MessageTemplates.postbackAddResult };
-      }
+			return {
+				success: true,
+				message: MessageTemplates.tokenDeleteSuccess,
+			};
+		} catch (error) {
+			console.error("Failed to cleanup on unfollow", {
+				userId,
+				action: "unfollow",
+				error,
+			});
+			return {
+				success: false,
+				message: MessageTemplates.tokenDeleteFailure,
+			};
+		}
+	}
 
-      if (isDeleteCalendarPostback(parsedUnknown)) {
-        await this.userCalendarRepository.deleteCalendar(userId, parsedUnknown.calendarId);
-        const name = parsedUnknown.calendarName || parsedUnknown.calendarId;
-        await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
-          MessageTemplates.postbackDeleteReply(name),
-        ]);
-        return { success: true, message: MessageTemplates.postbackDeleteResult };
-      }
+	private async handlePostback(webhookEvent: PostbackEventType): Promise<WebhookUseCaseResult | null> {
+		try {
+			const userId = webhookEvent.source.userId;
+			const data = webhookEvent.postback.data;
+			const parsedUnknown = JSON.parse(data) as unknown;
 
-      return null;
-    } catch (error) {
-      console.error("Failed to handle postback", {
-        userId: webhookEvent.source.userId,
-        action: "postback",
-        rawData: webhookEvent.postback.data,
-        error,
-      });
-      return { success: false, message: MessageTemplates.postbackError };
-    }
-  }
+			if (isAddCalendarPostback(parsedUnknown)) {
+				await this.userCalendarRepository.addCalendar({
+					userId,
+					calendarId: parsedUnknown.calendarId,
+					calendarName: parsedUnknown.calendarName,
+				});
+				await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
+					MessageTemplates.postbackAddReply(parsedUnknown.calendarName),
+				]);
+				return { success: true, message: MessageTemplates.postbackAddResult };
+			}
 
-  private async handleCalendarList(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-    try {
-      const calendars = await this.userCalendarRepository.getUserCalendars(userId);
-      if (calendars.length > 0) {
-        const lines = calendars.map((c) => `- ${c.calendarName} (${c.calendarId})`);
-        const message = [MessageTemplates.calendarListHeader, ...lines].join("\n");
-        await this.lineClient.replyTextMessages(replyToken, [message]);
-      } else {
-        await this.lineClient.replyTextMessages(replyToken, [
-          MessageTemplates.noSubscribedCalendars,
-        ]);
-      }
-      return {
-        success: true,
-        message: "カレンダー一覧を返信しました",
-      };
-    } catch (error) {
-      console.error("Failed to reply calendar list", {
-        userId,
-        action: "calendar_list",
-        error,
-      });
-      return {
-        success: false,
-        message: MessageTemplates.calendarListFailure,
-      };
-    }
-  }
+			if (isDeleteCalendarPostback(parsedUnknown)) {
+				await this.userCalendarRepository.deleteCalendar(userId, parsedUnknown.calendarId);
+				const name = parsedUnknown.calendarName || parsedUnknown.calendarId;
+				await this.lineClient.replyTextMessages(webhookEvent.replyToken, [
+					MessageTemplates.postbackDeleteReply(name),
+				]);
+				return { success: true, message: MessageTemplates.postbackDeleteResult };
+			}
 
-  private async handleCalendarAdd(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-    // Step 1: fetch token
-    let token;
-    try {
-      token = await this.tokenRepository.getToken(userId);
-    } catch (error) {
-      console.error("Failed to fetch token", {
-        userId,
-        action: "calendar_add_get_token",
-        error,
-      });
-      return { success: false, message: MessageTemplates.tokenFetchFailure };
-    }
+			return null;
+		} catch (error) {
+			console.error("Failed to handle postback", {
+				userId: webhookEvent.source.userId,
+				action: "postback",
+				rawData: webhookEvent.postback.data,
+				error,
+			});
+			return { success: false, message: MessageTemplates.postbackError };
+		}
+	}
 
-    // Step 2: if token is missing, send auth guidance and URL
-    if (!token) {
-      try {
-        const { url, state } = this.googleAuth.generateAuthUrl();
-        await this.stateRepository.saveState(state, userId);
-        await this.lineClient.replyTextWithQuickReply(
-          replyToken,
-          MessageTemplates.sendAuthGuidance,
-          [
-            {
-              type: "action",
-              action: {
-                type: "uri",
-                label: "Googleでログイン",
-                uri: url,
-              },
-            },
-          ]
-        );
-        return {
-          success: true,
-          message: MessageTemplates.sendAuthUrlResult,
-        };
-      } catch (error) {
-        console.error("Failed to send auth URL", {
-          userId,
-          action: "calendar_add_auth",
-          error,
-        });
-        return { success: false, message: MessageTemplates.authUrlSendFailure };
-      }
-    }
+	private async handleCalendarList(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+		try {
+			const calendars = await this.userCalendarRepository.getUserCalendars(userId);
+			if (calendars.length > 0) {
+				const lines = calendars.map((c) => `- ${c.calendarName} (${c.calendarId})`);
+				const message = [MessageTemplates.calendarListHeader, ...lines].join("\n");
+				await this.lineClient.replyTextMessages(replyToken, [message]);
+			} else {
+				await this.lineClient.replyTextMessages(replyToken, [
+					MessageTemplates.noSubscribedCalendars,
+				]);
+			}
+			return {
+				success: true,
+				message: "カレンダー一覧を返信しました",
+			};
+		} catch (error) {
+			console.error("Failed to reply calendar list", {
+				userId,
+				action: "calendar_list",
+				error,
+			});
+			return {
+				success: false,
+				message: MessageTemplates.calendarListFailure,
+			};
+		}
+	}
 
-    // Step 3: token exists → fetch calendar list and send quick reply
-    try {
-      this.googleAuth.setTokens(token);
-      const calendarApi = this.calendarApiFactory(this.googleAuth);
-      const list = await calendarApi.fetchCalendarList();
-      const calendarsForQuick = list
-        .filter((entry) => !!entry.id)
-        .map((entry) => ({
-          id: entry.id as string,
-          name: entry.summary || (entry.id as string) || "(no title)",
-        }));
-      const items = createCalendarQuickReplyItems(
-        calendarsForQuick,
-        ADD_CALENDAR_SELECT
-      );
-      await this.lineClient.replyTextWithQuickReply(
-        replyToken,
-        MessageTemplates.addQuickPrompt,
-        items
-      );
+	private async handleCalendarAdd(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+		// Step 1: fetch token
+		let token;
+		try {
+			token = await this.tokenRepository.getToken(userId);
+		} catch (error) {
+			console.error("Failed to fetch token", {
+				userId,
+				action: "calendar_add_get_token",
+				error,
+			});
+			return { success: false, message: MessageTemplates.tokenFetchFailure };
+		}
 
-      return { success: true, message: MessageTemplates.addQuickResult };
-    } catch (error) {
-      console.error("Failed to send add-calendar quick reply", {
-        userId,
-        action: "calendar_add_quick_reply",
-        error,
-      });
-      return { success: false, message: MessageTemplates.addQuickFailure };
-    }
-  }
+		// Step 2: if token is missing, send auth guidance and URL
+		if (!token) {
+			try {
+				const { url, state } = this.googleAuth.generateAuthUrl();
+				await this.stateRepository.saveState(state, userId);
+				await this.lineClient.replyTextWithQuickReply(
+					replyToken,
+					MessageTemplates.sendAuthGuidance,
+					[
+						{
+							type: "action",
+							action: {
+								type: "uri",
+								label: "Googleでログイン",
+								uri: url,
+							},
+						},
+					]
+				);
+				return {
+					success: true,
+					message: MessageTemplates.sendAuthUrlResult,
+				};
+			} catch (error) {
+				console.error("Failed to send auth URL", {
+					userId,
+					action: "calendar_add_auth",
+					error,
+				});
+				return { success: false, message: MessageTemplates.authUrlSendFailure };
+			}
+		}
 
-  private async handleCalendarDelete(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-    try {
-      const calendars = await this.userCalendarRepository.getUserCalendars(userId);
-      if (calendars.length === 0) {
-        await this.lineClient.replyTextMessages(replyToken, [
-          MessageTemplates.noSubscribedCalendars,
-        ]);
-        return { success: true, message: MessageTemplates.deleteNoTargetResult };
-      }
-      const calendarsForQuick = calendars.map((entry) => ({
-        id: entry.calendarId,
-        name: entry.calendarName || entry.calendarId,
-      }));
-      const items = createCalendarQuickReplyItems(
-        calendarsForQuick,
-        DELETE_CALENDAR_SELECT
-      );
-      await this.lineClient.replyTextWithQuickReply(
-        replyToken,
-        MessageTemplates.deleteQuickPrompt,
-        items
-      );
-      return { success: true, message: MessageTemplates.deleteQuickResult };
-    } catch (error) {
-      console.error("Failed to send delete-calendar quick reply", {
-        userId,
-        action: "calendar_delete_quick_reply",
-        error,
-      });
-      return { success: false, message: MessageTemplates.deleteQuickFailure };
-    }
-  }
+		// Step 3: token exists → fetch calendar list and send quick reply
+		try {
+			this.googleAuth.setTokens(token);
+			const calendarApi = this.calendarApiFactory(this.googleAuth);
+			const list = await calendarApi.fetchCalendarList();
+			const calendarsForQuick = list
+				.filter((entry) => !!entry.id)
+				.map((entry) => ({
+					id: entry.id as string,
+					name: entry.summary || (entry.id as string) || "(no title)",
+				}));
+			const items = createCalendarQuickReplyItems(
+				calendarsForQuick,
+				ADD_CALENDAR_SELECT
+			);
+			await this.lineClient.replyTextWithQuickReply(
+				replyToken,
+				MessageTemplates.addQuickPrompt,
+				items
+			);
 
-  private async handleHelp(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
-    try {
-      await this.lineClient.replyTextMessages(replyToken, [MessageTemplates.helpText]);
-      return { success: true, message: MessageTemplates.helpResult };
-    } catch (error) {
-      console.error("Failed to send help message", {
-        userId,
-        action: "help",
-        error,
-      });
-      return { success: false, message: MessageTemplates.helpSendFailure };
-    }
-  }
+			return { success: true, message: MessageTemplates.addQuickResult };
+		} catch (error) {
+			console.error("Failed to send add-calendar quick reply", {
+				userId,
+				action: "calendar_add_quick_reply",
+				error,
+			});
+			return { success: false, message: MessageTemplates.addQuickFailure };
+		}
+	}
 
-  private async handleMessage(webhookEvent: MessageEventType): Promise<WebhookUseCaseResult | null> {
-    if (webhookEvent.message.type !== "text") return null;
-    const text = webhookEvent.message.text;
+	private async handleCalendarDelete(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+		try {
+			const calendars = await this.userCalendarRepository.getUserCalendars(userId);
+			if (calendars.length === 0) {
+				await this.lineClient.replyTextMessages(replyToken, [
+					MessageTemplates.noSubscribedCalendars,
+				]);
+				return { success: true, message: MessageTemplates.deleteNoTargetResult };
+			}
+			const calendarsForQuick = calendars.map((entry) => ({
+				id: entry.calendarId,
+				name: entry.calendarName || entry.calendarId,
+			}));
+			const items = createCalendarQuickReplyItems(
+				calendarsForQuick,
+				DELETE_CALENDAR_SELECT
+			);
+			await this.lineClient.replyTextWithQuickReply(
+				replyToken,
+				MessageTemplates.deleteQuickPrompt,
+				items
+			);
+			return { success: true, message: MessageTemplates.deleteQuickResult };
+		} catch (error) {
+			console.error("Failed to send delete-calendar quick reply", {
+				userId,
+				action: "calendar_delete_quick_reply",
+				error,
+			});
+			return { success: false, message: MessageTemplates.deleteQuickFailure };
+		}
+	}
 
-    if (/^(?:カレンダー一覧|カレンダー)$/.test(text)) {
-      return this.handleCalendarList(webhookEvent.source.userId, webhookEvent.replyToken);
-    }
-    if (text === "カレンダー追加") {
-      return this.handleCalendarAdd(webhookEvent.source.userId, webhookEvent.replyToken);
-    }
-    if (text === "カレンダー削除") {
-      return this.handleCalendarDelete(webhookEvent.source.userId, webhookEvent.replyToken);
-    }
-    if (/^(?:ヘルプ|help)$/i.test(text)) {
-      return this.handleHelp(webhookEvent.source.userId, webhookEvent.replyToken);
-    }
+	private async handleHelp(userId: string, replyToken: string): Promise<WebhookUseCaseResult> {
+		try {
+			await this.lineClient.replyTextMessages(replyToken, [MessageTemplates.helpText]);
+			return { success: true, message: MessageTemplates.helpResult };
+		} catch (error) {
+			console.error("Failed to send help message", {
+				userId,
+				action: "help",
+				error,
+			});
+			return { success: false, message: MessageTemplates.helpSendFailure };
+		}
+	}
 
-    return null;
-  }
+	private async handleMessage(webhookEvent: MessageEventType): Promise<WebhookUseCaseResult | null> {
+		if (webhookEvent.message.type !== "text") return null;
+		const text = webhookEvent.message.text;
 
-  async handleWebhookEvent(
-    webhookEvent: LineWebhookEvent
-  ): Promise<WebhookUseCaseResult> {
-    if (!webhookEvent) {
-      return {
-        success: true,
-        message: MessageTemplates.noEvent,
-      };
-    }
+		if (/^(?:カレンダー一覧|カレンダー)$/.test(text)) {
+			return this.handleCalendarList(webhookEvent.source.userId, webhookEvent.replyToken);
+		}
+		if (text === "カレンダー追加") {
+			return this.handleCalendarAdd(webhookEvent.source.userId, webhookEvent.replyToken);
+		}
+		if (text === "カレンダー削除") {
+			return this.handleCalendarDelete(webhookEvent.source.userId, webhookEvent.replyToken);
+		}
+		if (/^(?:ヘルプ|help)$/i.test(text)) {
+			return this.handleHelp(webhookEvent.source.userId, webhookEvent.replyToken);
+		}
 
-    if (webhookEvent.type === "unfollow") {
-      return this.handleUnfollow(webhookEvent);
-    }
+		return null;
+	}
 
-    if (webhookEvent.type === "postback") {
-      const postbackResult = await this.handlePostback(webhookEvent);
-      if (postbackResult) return postbackResult;
-    }
+	async handleWebhookEvent(
+		webhookEvent: LineWebhookEvent
+	): Promise<WebhookUseCaseResult> {
+		if (!webhookEvent) {
+			return {
+				success: true,
+				message: MessageTemplates.noEvent,
+			};
+		}
 
-    if (isTextMessageEvent(webhookEvent)) {
-      const messageResult = await this.handleMessage(webhookEvent);
-      if (messageResult) return messageResult;
-    }
+		if (webhookEvent.type === "unfollow") {
+			return this.handleUnfollow(webhookEvent);
+		}
 
-    return {
-      success: true,
-      message: MessageTemplates.unsupportedMessage,
-    };
-  }
+		if (webhookEvent.type === "postback") {
+			const postbackResult = await this.handlePostback(webhookEvent);
+			if (postbackResult) return postbackResult;
+		}
+
+		if (isTextMessageEvent(webhookEvent)) {
+			const messageResult = await this.handleMessage(webhookEvent);
+			if (messageResult) return messageResult;
+		}
+
+		return {
+			success: true,
+			message: MessageTemplates.unsupportedMessage,
+		};
+	}
 }


### PR DESCRIPTION
Delete UserCalendar entries when an unfollow event occurs to ensure complete data removal.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755390179848179?thread_ts=1755390179.848179&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-f7d2b4a4-119b-49be-9b2c-060a1b12df21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7d2b4a4-119b-49be-9b2c-060a1b12df21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

