### PR TITLE
Implement foundational infrastructure for PR1

### DIFF
--- a/__tests__/usecases/commands/registry.test.ts
+++ b/__tests__/usecases/commands/registry.test.ts
@@ -1,0 +1,44 @@
+import { expect, test, describe } from "bun:test";
+import { CommandRegistry } from "../../../src/usecases/commands/registry";
+
+const dummyHandler = (name: string, aliases?: string[]) => ({
+	name,
+	aliases,
+	canHandle: () => false,
+	handle: async () => ({ success: true, message: "ok" }),
+});
+
+describe("CommandRegistry", () => {
+	test("register and getByName by canonical name", () => {
+		const reg = new CommandRegistry();
+		reg.register(dummyHandler("List"));
+		expect(reg.getByName("list")?.name).toBe("List");
+		expect(reg.getByName(" list ")?.name).toBe("List");
+	});
+
+	test("register with alias and resolve by alias", () => {
+		const reg = new CommandRegistry();
+		reg.register(dummyHandler("list", ["ls", "一覧"]));
+		expect(reg.getByName("ls")?.name).toBe("list");
+		expect(reg.getByName("一覧")?.name).toBe("list");
+	});
+
+	test("duplicate name throws", () => {
+		const reg = new CommandRegistry();
+		reg.register(dummyHandler("list"));
+		expect(() => reg.register(dummyHandler("LIST"))).toThrow();
+	});
+
+	test("alias conflict throws", () => {
+		const reg = new CommandRegistry();
+		reg.register(dummyHandler("list"));
+		expect(() => reg.register(dummyHandler("other", ["List"])) ).toThrow();
+	});
+
+	test("list returns unique handlers", () => {
+		const reg = new CommandRegistry();
+		const h = dummyHandler("a", ["b"]);
+		reg.register(h);
+		expect(reg.list()).toHaveLength(1);
+	});
+});

--- a/__tests__/usecases/commands/router.test.ts
+++ b/__tests__/usecases/commands/router.test.ts
@@ -1,0 +1,40 @@
+import { expect, test, describe } from "bun:test";
+import { CommandRegistry } from "../../../src/usecases/commands/registry";
+import { MessageRouter } from "../../../src/usecases/commands/router";
+import type { CommandHandler } from "../../../src/types/command";
+
+const makeHandler = (name: string, can: (input: string) => boolean): CommandHandler => ({
+	name,
+	canHandle: async (input) => can(input),
+	handle: async (input) => ({ success: true, message: `handled:${name}:${input}` }),
+});
+
+describe("MessageRouter", () => {
+	test("resolves by direct name/alias (case-insensitive, trimmed)", async () => {
+		const reg = new CommandRegistry();
+		const h = makeHandler("list", () => false);
+		(h as any).aliases = ["ls"];
+		reg.register(h);
+		const router = new MessageRouter(reg);
+		const ctx = { userId: "u" };
+		const r1 = await router.route(" list ", ctx);
+		expect(r1?.message).toBe("handled:list:list");
+		const r2 = await router.route("LS", ctx);
+		expect(r2?.message).toBe("handled:list:LS");
+	});
+
+	test("falls back to predicate when no direct match", async () => {
+		const reg = new CommandRegistry();
+		reg.register(makeHandler("echo", (i) => i.startsWith("echo ")));
+		const router = new MessageRouter(reg);
+		const res = await router.route("echo hello", { userId: "u" });
+		expect(res?.message).toBe("handled:echo:echo hello");
+	});
+
+	test("returns undefined when no handler matches", async () => {
+		const reg = new CommandRegistry();
+		const router = new MessageRouter(reg);
+		const res = await router.route("unknown", { userId: "u" });
+		expect(res).toBeUndefined();
+	});
+});

--- a/src/types/command.d.ts
+++ b/src/types/command.d.ts
@@ -1,0 +1,46 @@
+export type CommandName = string;
+
+/**
+ * Context provided to command handlers during routing and execution.
+ * Contains caller identity, optional locale, and optionally shared services/loggers.
+ */
+export type CommandContext = {
+	/** LINE user id */
+	userId: string;
+	/** Optional replyToken if available in the flow */
+	replyToken?: string;
+	/** BCP-47 language tag (e.g. "ja", "en-US") */
+	locale?: string;
+	/** Arbitrary service container for external I/O or gateways */
+	services?: unknown;
+	/** Console compatible logger */
+	logger?: Pick<Console, "debug" | "info" | "warn" | "error">;
+};
+
+/**
+ * Result produced by a command handler. This is intentionally minimal so
+ * that it maps one-to-one onto `WebhookUseCaseResult` without ambiguity.
+ */
+export type CommandResult = {
+	success: boolean;
+	/** Primary human-readable message for the caller */
+	message: string;
+};
+
+/**
+ * Single-responsibility command handler which can decide whether it can
+ * process a given input and, if so, produce a `CommandResult`.
+ */
+export interface CommandHandler {
+	/** Canonical name of the command (case-insensitive) */
+	readonly name: CommandName;
+	/** Optional aliases for discovery (case-insensitive) */
+	readonly aliases?: CommandName[];
+	/**
+	 * Quick predicate hint for router/registry-based resolution.
+	 * Should be side-effect free.
+	 */
+	canHandle: (input: string, context: CommandContext) => boolean | Promise<boolean>;
+	/** Execute the command. */
+	handle: (input: string, context: CommandContext) => Promise<CommandResult>;
+}

--- a/src/usecases/commands/registry.ts
+++ b/src/usecases/commands/registry.ts
@@ -1,0 +1,43 @@
+import type { CommandHandler, CommandName } from "../../types/command";
+
+/**
+ * Registry to hold and resolve command handlers by name or predicate.
+ * Non-mutating lookups; registration is idempotent by canonical name.
+ */
+export class CommandRegistry {
+	private readonly nameToHandler: Map<string, CommandHandler> = new Map();
+
+	/** Register a handler. Throws on conflicting duplicate canonical name. */
+	register(handler: CommandHandler): void {
+		const canonical = this.canonicalize(handler.name);
+		if (this.nameToHandler.has(canonical)) {
+			throw new Error(`Command already registered: ${handler.name}`);
+		}
+		this.nameToHandler.set(canonical, handler);
+
+		if (handler.aliases) {
+			for (const alias of handler.aliases) {
+				const a = this.canonicalize(alias);
+				if (this.nameToHandler.has(a)) {
+					throw new Error(`Alias conflicts with existing command: ${alias}`);
+				}
+				this.nameToHandler.set(a, handler);
+			}
+		}
+	}
+
+	/** Find by exact name or alias (case-insensitive, trimmed). */
+	getByName(name: CommandName): CommandHandler | undefined {
+		const key = this.canonicalize(name);
+		return this.nameToHandler.get(key);
+	}
+
+	/** Return all unique handlers (deduped by instance). */
+	list(): CommandHandler[] {
+		return Array.from(new Set(this.nameToHandler.values()));
+	}
+
+	private canonicalize(input: string): string {
+		return input.trim().toLowerCase();
+	}
+}

--- a/src/usecases/commands/router.ts
+++ b/src/usecases/commands/router.ts
@@ -1,0 +1,35 @@
+import type { CommandContext, CommandResult } from "../../types/command";
+import { CommandRegistry } from "./registry";
+
+/**
+ * MessageRouter takes raw text input, normalizes it, resolves a handler,
+ * and executes it. This skeleton does not include fallback behavior.
+ */
+export class MessageRouter {
+	constructor(private readonly registry: CommandRegistry) {}
+
+	/** Normalize text for matching: trim and case-fold to lower. */
+	private normalize(text: string): string {
+		return text.trim();
+	}
+
+	/**
+	 * Resolve by exact name/alias first, otherwise consult canHandle on all.
+	 * Returns undefined when nothing matches.
+	 */
+	async route(input: string, context: CommandContext): Promise<CommandResult | undefined> {
+		const normalized = this.normalize(input);
+		const direct = this.registry.getByName(normalized.toLowerCase());
+		if (direct) {
+			return await direct.handle(normalized, context);
+		}
+
+		for (const handler of this.registry.list()) {
+			const ok = await handler.canHandle(normalized, context);
+			if (ok) {
+				return await handler.handle(normalized, context);
+			}
+		}
+		return undefined;
+	}
+}


### PR DESCRIPTION
Introduce a command handling framework (types, registry, router) as a non-behavioral foundation for future LINE webhook use cases.

---
[Slack Thread](https://makoto-bd-private.slack.com/archives/C097HNXTZFY/p1755877951619519?thread_ts=1755877951.619519&cid=C097HNXTZFY)

<a href="https://cursor.com/background-agent?bcId=bc-8fe030af-3bfb-4acb-9d79-2866b146f0db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fe030af-3bfb-4acb-9d79-2866b146f0db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

